### PR TITLE
feat: 회원가입 api 구현

### DIFF
--- a/src/main/java/com/back/b2st/domain/member/controller/MemberController.java
+++ b/src/main/java/com/back/b2st/domain/member/controller/MemberController.java
@@ -1,25 +1,27 @@
 package com.back.b2st.domain.member.controller;
 
-import com.back.b2st.domain.member.dto.SignupRequest;
-import com.back.b2st.domain.member.service.MemberService;
-import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.back.b2st.domain.member.dto.SignupRequest;
+import com.back.b2st.domain.member.service.MemberService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
 @RestController
 @RequestMapping("/members")
 @RequiredArgsConstructor
 public class MemberController {
 
-    private final MemberService memberService;
+	private final MemberService memberService;
 
-    @PostMapping("/signup")
-    public ResponseEntity<String> signup(@Valid @RequestBody SignupRequest request) {
-        Long memberId = memberService.signup(request);
-        return ResponseEntity.ok("(response 수정 필요)회원가입 성공 ID: " + memberId);
-    }
+	@PostMapping("/signup")
+	public ResponseEntity<String> signup(@Valid @RequestBody SignupRequest request) {
+		Long memberId = memberService.signup(request);
+		return ResponseEntity.ok("(response 수정 필요)회원가입 성공 ID: " + memberId);
+	}
 }

--- a/src/main/java/com/back/b2st/domain/member/dto/SignupRequest.java
+++ b/src/main/java/com/back/b2st/domain/member/dto/SignupRequest.java
@@ -1,34 +1,34 @@
 package com.back.b2st.domain.member.dto;
 
+import java.time.LocalDate;
+
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
-
 @Getter
 @NoArgsConstructor
 public class SignupRequest {
 
-    @NotBlank(message = "이메일은 필수입니다.")
-    @Email(message = "올바른 이메일 형식이 아닙니다.")
-    private String email;
+	@NotBlank(message = "이메일은 필수입니다.")
+	@Email(message = "올바른 이메일 형식이 아닙니다.")
+	private String email;
 
-    @NotBlank(message = "비밀번호는 필수입니다.")
-    // 비밀번호는 8~30자, 영문자+숫자+특수기호 포함
-    @Pattern(regexp = "^(?=.*[a-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,30}$",
-            message = "비밀번호는 8~30자, 영소문자+숫자+특수기호를 포함해야 합니다.")
-    private String password;
+	@NotBlank(message = "비밀번호는 필수입니다.")
+	// 비밀번호는 8~30자, 영문자+숫자+특수기호 포함
+	@Pattern(regexp = "^(?=.*[a-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,30}$",
+		message = "비밀번호는 8~30자, 영소문자+숫자+특수기호를 포함해야 합니다.")
+	private String password;
 
-    @NotBlank(message = "이름은 필수입니다.")
-    private String name;
+	@NotBlank(message = "이름은 필수입니다.")
+	private String name;
 
-    @NotBlank(message = "닉네임은 필수입니다.")
-    private String nickname;
+	@NotBlank(message = "닉네임은 필수입니다.")
+	private String nickname;
 
-    private String phone;
+	private String phone;
 
-    private LocalDate birth;
+	private LocalDate birth;
 }

--- a/src/main/java/com/back/b2st/domain/member/entity/Member.java
+++ b/src/main/java/com/back/b2st/domain/member/entity/Member.java
@@ -1,80 +1,90 @@
 package com.back.b2st.domain.member.entity;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
 import com.back.b2st.global.jpa.entity.BaseEntity;
-import jakarta.persistence.*;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "members", indexes = {
-        @Index(name = "idx_member_provider_id", columnList = "provider, provider_id")
+	@Index(name = "idx_member_provider_id", columnList = "provider, provider_id")
 })
 public class Member extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "member_id")
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "member_id")
+	private Long id;
 
-    @Column(nullable = false, unique = true)
-    private String email;
+	@Column(nullable = false, unique = true)
+	private String email;
 
-    @Column(nullable = true) // 소셜 로그인은 비밀번호 없을 수 있음
-    private String password;
+	@Column(nullable = true) // 소셜 로그인은 비밀번호 없을 수 있음
+	private String password;
 
-    @Column(nullable = false)
-    private String name;
+	@Column(nullable = false)
+	private String name;
 
-    @Column(nullable = false, unique = true)
-    private String nickname;
+	@Column(nullable = false, unique = true)
+	private String nickname;
 
-    private String phone;
+	private String phone;
 
-    private LocalDate birth;
+	private LocalDate birth;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private Role role; // MEMBER, ADMIN
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private Role role; // MEMBER, ADMIN
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private Provider provider; // EMAIL, KAKAO
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private Provider provider; // EMAIL, KAKAO
 
-    @Column(name = "provider_id")
-    private String providerId;
+	@Column(name = "provider_id")
+	private String providerId;
 
-    @Column(name = "is_verified")
-    private boolean isVerified; // 본인인증 여부
+	@Column(name = "is_verified")
+	private boolean isVerified; // 본인인증 여부
 
-    @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
 
-    @Builder
-    public Member(String email, String password, String name, String nickname, String phone, LocalDate birth, Role role, Provider provider, String providerId, boolean isVerified) {
-        this.email = email;
-        this.password = password;
-        this.name = name;
-        this.nickname = nickname;
-        this.phone = phone;
-        this.birth = birth;
-        this.role = role;
-        this.provider = provider;
-        this.providerId = providerId;
-        this.isVerified = isVerified;
-    }
+	@Builder
+	public Member(String email, String password, String name, String nickname, String phone, LocalDate birth, Role role,
+		Provider provider, String providerId, boolean isVerified) {
+		this.email = email;
+		this.password = password;
+		this.name = name;
+		this.nickname = nickname;
+		this.phone = phone;
+		this.birth = birth;
+		this.role = role;
+		this.provider = provider;
+		this.providerId = providerId;
+		this.isVerified = isVerified;
+	}
 
-    public enum Role {
-        MEMBER, ADMIN
-    }
+	public enum Role {
+		MEMBER, ADMIN
+	}
 
-    public enum Provider {
-        EMAIL, KAKAO
-    }
+	public enum Provider {
+		EMAIL, KAKAO
+	}
 }

--- a/src/main/java/com/back/b2st/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/back/b2st/domain/member/repository/MemberRepository.java
@@ -1,12 +1,15 @@
 package com.back.b2st.domain.member.repository;
 
-import com.back.b2st.domain.member.entity.Member;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
 
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.back.b2st.domain.member.entity.Member;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByEmail(String email);
-    boolean existsByEmail(String email);
-    boolean existsByNickname(String nickname);
+	Optional<Member> findByEmail(String email);
+
+	boolean existsByEmail(String email);
+
+	boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/back/b2st/domain/member/service/MemberService.java
+++ b/src/main/java/com/back/b2st/domain/member/service/MemberService.java
@@ -1,43 +1,45 @@
 package com.back.b2st.domain.member.service;
 
-import com.back.b2st.domain.member.dto.SignupRequest;
-import com.back.b2st.domain.member.entity.Member;
-import com.back.b2st.domain.member.repository.MemberRepository;
-import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.back.b2st.domain.member.dto.SignupRequest;
+import com.back.b2st.domain.member.entity.Member;
+import com.back.b2st.domain.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
 
-    private final MemberRepository memberRepository;
-    private final PasswordEncoder passwordEncoder;
+	private final MemberRepository memberRepository;
+	private final PasswordEncoder passwordEncoder;
 
-    @Transactional
-    public Long signup(SignupRequest request) {
-        if (memberRepository.existsByEmail(request.getEmail())) {
-            throw new IllegalArgumentException("이미 가입된 이메일입니다.");
-        }
-        if (memberRepository.existsByNickname(request.getNickname())) {
-            throw new IllegalArgumentException("이미 존재하는 닉네임입니다.");
-        }
+	@Transactional
+	public Long signup(SignupRequest request) {
+		if (memberRepository.existsByEmail(request.getEmail())) {
+			throw new IllegalArgumentException("이미 가입된 이메일입니다.");
+		}
+		if (memberRepository.existsByNickname(request.getNickname())) {
+			throw new IllegalArgumentException("이미 존재하는 닉네임입니다.");
+		}
 
-        // 비밀번호 암호화 및 엔티티 생성
-        Member member = Member.builder()
-                .email(request.getEmail())
-                .password(passwordEncoder.encode(request.getPassword()))
-                .name(request.getName())
-                .nickname(request.getNickname())
-                .phone(request.getPhone())
-                .birth(request.getBirth())
-                .role(Member.Role.MEMBER) // 기본 가입은 MEMBER
-                .provider(Member.Provider.EMAIL)
-                .isVerified(false) // 초기엔 미인증
-                .build();
+		// 비밀번호 암호화 및 엔티티 생성
+		Member member = Member.builder()
+			.email(request.getEmail())
+			.password(passwordEncoder.encode(request.getPassword()))
+			.name(request.getName())
+			.nickname(request.getNickname())
+			.phone(request.getPhone())
+			.birth(request.getBirth())
+			.role(Member.Role.MEMBER) // 기본 가입은 MEMBER
+			.provider(Member.Provider.EMAIL)
+			.isVerified(false) // 초기엔 미인증
+			.build();
 
-        // 저장
-        return memberRepository.save(member).getId();
-    }
+		// 저장
+		return memberRepository.save(member).getId();
+	}
 }

--- a/src/main/java/com/back/b2st/security/SecurityConfig.java
+++ b/src/main/java/com/back/b2st/security/SecurityConfig.java
@@ -13,20 +13,20 @@ import org.springframework.security.web.SecurityFilterChain;
 @EnableWebSecurity
 public class SecurityConfig {
 
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
 
-    @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-                .csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/members/signup", "/auth/**", "/h2-console/**").permitAll() // 회원가입, 로그인은 모두 허용
-                        .anyRequest().authenticated() // 그 외는 인증 필요
-                );
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http
+			.csrf(AbstractHttpConfigurer::disable)
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers("/members/signup", "/auth/**", "/h2-console/**").permitAll() // 회원가입, 로그인은 모두 허용
+				.anyRequest().authenticated() // 그 외는 인증 필요
+			);
 
-        return http.build();
-    }
+		return http.build();
+	}
 }

--- a/src/test/java/com/back/b2st/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/back/b2st/domain/member/controller/MemberControllerTest.java
@@ -1,6 +1,11 @@
 package com.back.b2st.domain.member.controller;
 
-import com.back.b2st.domain.member.dto.SignupRequest;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDate;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,13 +16,10 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.back.b2st.domain.member.dto.SignupRequest;
+
 import tools.jackson.databind.ObjectMapper;
-
-import java.time.LocalDate;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -25,61 +27,61 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Transactional
 class MemberControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+	@Autowired
+	private MockMvc mockMvc;
 
-    @Autowired
-    private ObjectMapper objectMapper; // JSON 변환용
+	@Autowired
+	private ObjectMapper objectMapper; // JSON 변환용
 
-    @Test
-    @DisplayName("통합: 회원가입 성공")
-    void signup_integration_success() throws Exception {
-        // given
-        SignupRequest request = createSignupRequest("newuser@test.com", "StrongP@ss123", "신규유저", "NewNick");
+	@Test
+	@DisplayName("통합: 회원가입 성공")
+	void signup_integration_success() throws Exception {
+		// given
+		SignupRequest request = createSignupRequest("newuser@test.com", "StrongP@ss123", "신규유저", "NewNick");
 
-        // when & then
-        mockMvc.perform(post("/members/signup")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andDo(print())
-                .andExpect(status().isOk());
-    }
+		// when & then
+		mockMvc.perform(post("/members/signup")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andDo(print())
+			.andExpect(status().isOk());
+	}
 
-    @Test
-    @DisplayName("통합: 회원가입 실패 - 유효하지 않은 이메일 형식")
-    void signup_integration_fail_bad_email() throws Exception {
-        // given
-        SignupRequest request = createSignupRequest("bad-email", "StrongP@ss123", "신규유저", "NewNick");
+	@Test
+	@DisplayName("통합: 회원가입 실패 - 유효하지 않은 이메일 형식")
+	void signup_integration_fail_bad_email() throws Exception {
+		// given
+		SignupRequest request = createSignupRequest("bad-email", "StrongP@ss123", "신규유저", "NewNick");
 
-        // when & then
-        mockMvc.perform(post("/members/signup")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andDo(print())
-                .andExpect(status().isBadRequest());
-    }
+		// when & then
+		mockMvc.perform(post("/members/signup")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andDo(print())
+			.andExpect(status().isBadRequest());
+	}
 
-    @Test
-    @DisplayName("통합: 회원가입 실패 - 비밀번호 규칙 미준수")
-    void signup_integration_fail_weak_password() throws Exception {
-        // given (특문 미포함)
-        SignupRequest request = createSignupRequest("user@test.com", "weakpassword1", "신규유저", "NewNick");
+	@Test
+	@DisplayName("통합: 회원가입 실패 - 비밀번호 규칙 미준수")
+	void signup_integration_fail_weak_password() throws Exception {
+		// given (특문 미포함)
+		SignupRequest request = createSignupRequest("user@test.com", "weakpassword1", "신규유저", "NewNick");
 
-        // when & then
-        mockMvc.perform(post("/members/signup")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andDo(print())
-                .andExpect(status().isBadRequest());
-    }
+		// when & then
+		mockMvc.perform(post("/members/signup")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andDo(print())
+			.andExpect(status().isBadRequest());
+	}
 
-    private SignupRequest createSignupRequest(String email, String pw, String name, String nick) {
-        SignupRequest request = new SignupRequest();
-        ReflectionTestUtils.setField(request, "email", email);
-        ReflectionTestUtils.setField(request, "password", pw);
-        ReflectionTestUtils.setField(request, "name", name);
-        ReflectionTestUtils.setField(request, "nickname", nick);
-        ReflectionTestUtils.setField(request, "birth", LocalDate.of(1990, 1, 1));
-        return request;
-    }
+	private SignupRequest createSignupRequest(String email, String pw, String name, String nick) {
+		SignupRequest request = new SignupRequest();
+		ReflectionTestUtils.setField(request, "email", email);
+		ReflectionTestUtils.setField(request, "password", pw);
+		ReflectionTestUtils.setField(request, "name", name);
+		ReflectionTestUtils.setField(request, "nickname", nick);
+		ReflectionTestUtils.setField(request, "birth", LocalDate.of(1990, 1, 1));
+		return request;
+	}
 }

--- a/src/test/java/com/back/b2st/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/back/b2st/domain/member/service/MemberServiceTest.java
@@ -1,8 +1,11 @@
 package com.back.b2st.domain.member.service;
 
-import com.back.b2st.domain.member.dto.SignupRequest;
-import com.back.b2st.domain.member.entity.Member;
-import com.back.b2st.domain.member.repository.MemberRepository;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDate;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,75 +15,68 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.time.LocalDate;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
+import com.back.b2st.domain.member.dto.SignupRequest;
+import com.back.b2st.domain.member.entity.Member;
+import com.back.b2st.domain.member.repository.MemberRepository;
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
 
-    @InjectMocks
-    private MemberService memberService;
+	@InjectMocks
+	private MemberService memberService;
 
-    @Mock
-    private MemberRepository memberRepository;
+	@Mock
+	private MemberRepository memberRepository;
 
-    @Mock
-    private PasswordEncoder passwordEncoder;
+	@Mock
+	private PasswordEncoder passwordEncoder;
 
-    @Test
-    @DisplayName("회원가입 성공 테스트")
-    void signup_success() {
-        // given
-        SignupRequest request = createSignupRequest("test@email.com", "validPw123!", "tester", "nickname");
+	@Test
+	@DisplayName("회원가입 성공 테스트")
+	void signup_success() {
+		// given
+		SignupRequest request = createSignupRequest("test@email.com", "validPw123!", "tester", "nickname");
 
-        // Mocking
-        given(memberRepository.existsByEmail(request.getEmail())).willReturn(false);
-        given(memberRepository.existsByNickname(request.getNickname())).willReturn(false);
-        given(passwordEncoder.encode(request.getPassword())).willReturn("encodedPassword");
+		// Mocking
+		given(memberRepository.existsByEmail(request.getEmail())).willReturn(false);
+		given(memberRepository.existsByNickname(request.getNickname())).willReturn(false);
+		given(passwordEncoder.encode(request.getPassword())).willReturn("encodedPassword");
 
-        // Mocking: save 호출 시 ID가 1인 Member 반환하도록
-        Member savedMember = Member.builder()
-                .email(request.getEmail())
-                .role(Member.Role.MEMBER)
-                .build();
-        ReflectionTestUtils.setField(savedMember, "id", 1L);
-        given(memberRepository.save(any(Member.class))).willReturn(savedMember);
+		// Mocking: save 호출 시 ID가 1인 Member 반환하도록
+		Member savedMember = Member.builder().email(request.getEmail()).role(Member.Role.MEMBER).build();
+		ReflectionTestUtils.setField(savedMember, "id", 1L);
+		given(memberRepository.save(any(Member.class))).willReturn(savedMember);
 
-        // when
-        Long memberId = memberService.signup(request);
+		// when
+		Long memberId = memberService.signup(request);
 
-        // then
-        assertThat(memberId).isEqualTo(1L);
-    }
+		// then
+		assertThat(memberId).isEqualTo(1L);
+	}
 
-    @Test
-    @DisplayName("회원가입 실패 - 이메일 중복")
-    void signup_fail_duplicate_email() {
-        // given
-        SignupRequest request = createSignupRequest("duplicate@email.com", "pw", "name", "nick");
+	@Test
+	@DisplayName("회원가입 실패 - 이메일 중복")
+	void signup_fail_duplicate_email() {
+		// given
+		SignupRequest request = createSignupRequest("duplicate@email.com", "pw", "name", "nick");
 
-        // Mocking
-        given(memberRepository.existsByEmail(request.getEmail())).willReturn(true);
+		// Mocking
+		given(memberRepository.existsByEmail(request.getEmail())).willReturn(true);
 
-        // when & then
-        assertThatThrownBy(() -> memberService.signup(request))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("이미 가입된 이메일입니다.");
-    }
+		// when & then
+		assertThatThrownBy(() -> memberService.signup(request)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("이미 가입된 이메일입니다.");
+	}
 
-    // 테스트용 DTO 생성 헬퍼 메서드
-    private SignupRequest createSignupRequest(String email, String pw, String name, String nick) {
-        SignupRequest request = new SignupRequest();
-        // Reflection
-        ReflectionTestUtils.setField(request, "email", email);
-        ReflectionTestUtils.setField(request, "password", pw);
-        ReflectionTestUtils.setField(request, "name", name);
-        ReflectionTestUtils.setField(request, "nickname", nick);
-        ReflectionTestUtils.setField(request, "birth", LocalDate.of(2000, 1, 1));
-        return request;
-    }
+	// 테스트용 DTO 생성 헬퍼 메서드
+	private SignupRequest createSignupRequest(String email, String pw, String name, String nick) {
+		SignupRequest request = new SignupRequest();
+		// Reflection
+		ReflectionTestUtils.setField(request, "email", email);
+		ReflectionTestUtils.setField(request, "password", pw);
+		ReflectionTestUtils.setField(request, "name", name);
+		ReflectionTestUtils.setField(request, "nickname", nick);
+		ReflectionTestUtils.setField(request, "birth", LocalDate.of(2000, 1, 1));
+		return request;
+	}
 }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 관련 이슈
- close #17 

</br>

## 작업 내용
- member 도메인의 엔티티 및 컴포넌트 생성
- MemberController 메서드 signup 추가
- 유닛ㆍ통합 테스트 코드 작성

### 참고 사항
- 비밀번호는 제약조건으로 '8~30자, 영문자+숫자+특수기호 포함'
- BaseResponse 적용 전, 임시로 ResponseEntity.ok return

</br>

## 체크리스트
- [x] 코딩 컨벤션 준수
- [ ] 불필요한 코드 제거
- [x] 테스트 완료
