### PR TITLE
feat: 환불 계좌 관리 api 구현

### DIFF
--- a/src/main/java/com/back/b2st/domain/auth/error/AuthErrorCode.java
+++ b/src/main/java/com/back/b2st/domain/auth/error/AuthErrorCode.java
@@ -23,10 +23,7 @@ public enum AuthErrorCode implements ErrorCode {
 	// General Token
 	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A406", "만료된 토큰입니다."),
 	UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "A407", "지원하지 않는 토큰 형식입니다."),
-	EMPTY_CLAIMS(HttpStatus.UNAUTHORIZED, "A408", "토큰에 권한 정보가 없습니다."),
-
-	// User
-	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "A409", "해당하는 회원을 찾을 수 없습니다.");
+	EMPTY_CLAIMS(HttpStatus.UNAUTHORIZED, "A408", "토큰에 권한 정보가 없습니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/src/main/java/com/back/b2st/domain/member/controller/MypageController.java
+++ b/src/main/java/com/back/b2st/domain/member/controller/MypageController.java
@@ -3,13 +3,17 @@ package com.back.b2st.domain.member.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.back.b2st.domain.member.dto.MyInfoResponse;
 import com.back.b2st.domain.member.dto.PasswordChangeRequest;
+import com.back.b2st.domain.member.dto.RefundAccountReq;
+import com.back.b2st.domain.member.dto.RefundAccountRes;
 import com.back.b2st.domain.member.service.MemberService;
+import com.back.b2st.domain.member.service.RefundAccountService;
 import com.back.b2st.global.annotation.CurrentUser;
 import com.back.b2st.global.common.BaseResponse;
 import com.back.b2st.security.UserPrincipal;
@@ -22,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 public class MypageController {
 
 	private final MemberService memberService;
+	private final RefundAccountService refundAccountService;
 
 	@GetMapping("/me")
 	public ResponseEntity<BaseResponse<MyInfoResponse>> getMyInfo(@CurrentUser UserPrincipal userPrincipal) {
@@ -35,5 +40,19 @@ public class MypageController {
 		@RequestBody PasswordChangeRequest request) {
 		memberService.changePassword(userPrincipal.getId(), request);
 		return BaseResponse.success(null);
+	}
+
+	@PostMapping("/account")
+	public BaseResponse<Void> setRefunAccount(
+		@CurrentUser UserPrincipal userPrincipal,
+		@RequestBody RefundAccountReq refundAccountReq) {
+		refundAccountService.saveAccount(userPrincipal.getId(), refundAccountReq);
+		return BaseResponse.success(null);
+	}
+
+	@GetMapping("/account")
+	public BaseResponse<RefundAccountRes> getRefundAccount(@CurrentUser UserPrincipal userPrincipal) {
+		RefundAccountRes response = refundAccountService.getAccount(userPrincipal.getId());
+		return BaseResponse.success(response);
 	}
 }

--- a/src/main/java/com/back/b2st/domain/member/dto/RefundAccountReq.java
+++ b/src/main/java/com/back/b2st/domain/member/dto/RefundAccountReq.java
@@ -1,0 +1,28 @@
+package com.back.b2st.domain.member.dto;
+
+import com.back.b2st.global.common.BankCode;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class RefundAccountReq {
+
+	@NotNull(message = "은행 코드는 필수입니다.")
+	private BankCode bankCode;
+
+	@NotNull(message = "계좌번호는 필수입니다.")
+	@Pattern(regexp = "^[0-9]+$", message = "계좌번호는 숫자만 입력해주세요.")
+	private String accountNumber;
+
+	@NotNull(message = "예금주명은 필수입니다.")
+	private String holderName;
+}

--- a/src/main/java/com/back/b2st/domain/member/dto/RefundAccountRes.java
+++ b/src/main/java/com/back/b2st/domain/member/dto/RefundAccountRes.java
@@ -1,0 +1,25 @@
+package com.back.b2st.domain.member.dto;
+
+import com.back.b2st.domain.member.entity.RefundAccount;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RefundAccountRes {
+
+	private String bankCode;
+	private String bankName;
+	private String accountNumber;
+	private String holderName;
+
+	public static RefundAccountRes from(RefundAccount entity) {
+		return RefundAccountRes.builder()
+			.bankCode(entity.getBankCode().getCode())
+			.bankName(entity.getBankCode().getDescription())
+			.accountNumber(entity.getAccountNumber())
+			.holderName(entity.getHolderName())
+			.build();
+	}
+}

--- a/src/main/java/com/back/b2st/domain/member/entity/RefundAccount.java
+++ b/src/main/java/com/back/b2st/domain/member/entity/RefundAccount.java
@@ -1,0 +1,66 @@
+package com.back.b2st.domain.member.entity;
+
+import com.back.b2st.global.common.BankCode;
+import com.back.b2st.global.jpa.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "refund_accounts")
+@SequenceGenerator(
+	name = "refund_account_id_gen",
+	sequenceName = "refund_accounts_seq",
+	allocationSize = 50
+)
+public class RefundAccount extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "refund_account_id_gen")
+	@Column(name = "account_id")
+	private Long id;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false, unique = true)
+	private Member member;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private BankCode bankCode;
+
+	@Column(nullable = false)
+	private String accountNumber;
+
+	@Column(nullable = false)
+	private String holderName;
+
+	@Builder
+	public RefundAccount(Member member, BankCode bankCode, String accountNumber, String holderName) {
+		this.member = member;
+		this.bankCode = bankCode; // 수정
+		this.accountNumber = accountNumber;
+		this.holderName = holderName;
+	}
+
+	public void updateAccount(BankCode bankCode, String accountNumber, String holderName) {
+		this.bankCode = bankCode; // 수정
+		this.accountNumber = accountNumber;
+		this.holderName = holderName;
+	}
+}

--- a/src/main/java/com/back/b2st/domain/member/error/MemberErrorCode.java
+++ b/src/main/java/com/back/b2st/domain/member/error/MemberErrorCode.java
@@ -1,0 +1,31 @@
+package com.back.b2st.domain.member.error;
+
+import org.springframework.http.HttpStatus;
+
+import com.back.b2st.global.error.code.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberErrorCode implements ErrorCode {
+
+	// 회원가입
+	DUPLICATE_EMAIL(HttpStatus.CONFLICT, "M401", "이미 가입된 이메일입니다."), // 409 Conflict
+	DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "M402", "이미 존재하는 닉네임입니다."),
+
+	// 조회
+	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M403", "해당하는 회원을 찾을 수 없습니다."),
+
+	// 비밀번호 변경
+	PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "M404", "현재 비밀번호가 일치하지 않습니다."),
+	SAME_PASSWORD(HttpStatus.BAD_REQUEST, "M405", "새 비밀번호는 기존 비밀번호와 다르게 설정해야 합니다."),
+
+	// 환불 계좌
+	REFUND_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "M406", "등록된 환불 계좌가 없습니다.");
+
+	private final HttpStatus status;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/back/b2st/domain/member/repository/RefundAccountRepository.java
+++ b/src/main/java/com/back/b2st/domain/member/repository/RefundAccountRepository.java
@@ -1,0 +1,12 @@
+package com.back.b2st.domain.member.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.back.b2st.domain.member.entity.Member;
+import com.back.b2st.domain.member.entity.RefundAccount;
+
+public interface RefundAccountRepository extends JpaRepository<RefundAccount, Long> {
+	Optional<RefundAccount> findByMember(Member member);
+}

--- a/src/main/java/com/back/b2st/domain/member/service/RefundAccountService.java
+++ b/src/main/java/com/back/b2st/domain/member/service/RefundAccountService.java
@@ -1,0 +1,56 @@
+package com.back.b2st.domain.member.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.b2st.domain.member.dto.RefundAccountReq;
+import com.back.b2st.domain.member.dto.RefundAccountRes;
+import com.back.b2st.domain.member.entity.Member;
+import com.back.b2st.domain.member.entity.RefundAccount;
+import com.back.b2st.domain.member.error.MemberErrorCode;
+import com.back.b2st.domain.member.repository.MemberRepository;
+import com.back.b2st.domain.member.repository.RefundAccountRepository;
+import com.back.b2st.global.error.exception.BusinessException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RefundAccountService {
+
+	private final RefundAccountRepository refundAccountRepository;
+	private final MemberRepository memberRepository;
+
+	@Transactional
+	public void saveAccount(Long memberId, RefundAccountReq request) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+		refundAccountRepository.findByMember(member).ifPresentOrElse(
+			existingAccount -> existingAccount.updateAccount(
+				request.getBankCode(),
+				request.getAccountNumber(),
+				request.getHolderName()
+			),
+			() -> {
+				RefundAccount newAccount = RefundAccount.builder()
+					.member(member)
+					.bankCode(request.getBankCode())
+					.accountNumber(request.getAccountNumber())
+					.holderName(request.getHolderName())
+					.build();
+				refundAccountRepository.save(newAccount);
+			}
+		);
+	}
+
+	@Transactional(readOnly = true)
+	public RefundAccountRes getAccount(Long memberId) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+		return refundAccountRepository.findByMember(member)
+			.map(RefundAccountRes::from)
+			.orElseThrow(() -> new BusinessException(MemberErrorCode.REFUND_ACCOUNT_NOT_FOUND));
+	}
+}

--- a/src/main/java/com/back/b2st/global/common/BankCode.java
+++ b/src/main/java/com/back/b2st/global/common/BankCode.java
@@ -1,0 +1,45 @@
+package com.back.b2st.global.common;
+
+import java.util.Arrays;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum BankCode {
+
+	KB("004", "KB국민은행"),
+	SC("023", "SC제일은행"),
+	CITY("027", "한국씨티은행"),
+	HANA("081", "하나은행"),
+	SHINHAN("088", "신한은행"),
+	K_BANK("089", "케이뱅크"),
+	KAKAO("090", "카카오뱅크"),
+	TOSS("092", "토스뱅크"),
+	WOORI("020", "우리은행"),
+	IBK("003", "IBK기업은행"),
+	NONGHYUP("011", "NH농협은행"),
+	SAEMAUL("045", "새마을금고"),
+	SHINHYUP("048", "신협"),
+	POST("071", "우체국");
+
+	private final String code;
+	private final String description;
+
+	@JsonCreator
+	public static BankCode fromCode(String code) {
+		return Arrays.stream(BankCode.values())
+			.filter(bank -> bank.getCode().equals(code))
+			.findFirst()
+			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 은행 코드입니다: " + code));
+	}
+
+	@JsonValue
+	public String getCode() {
+		return code;
+	}
+}

--- a/src/main/java/com/back/b2st/global/common/controller/CommonController.java
+++ b/src/main/java/com/back/b2st/global/common/controller/CommonController.java
@@ -1,0 +1,27 @@
+package com.back.b2st.global.common.controller;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.back.b2st.global.common.BankCode;
+import com.back.b2st.global.common.BaseResponse;
+import com.back.b2st.global.common.dto.BankRes;
+
+@RestController
+@RequestMapping("/common")
+public class CommonController {
+
+	@GetMapping("/banks")
+	public BaseResponse<List<BankRes>> getBankList() {
+		List<BankRes> banks = Arrays.stream(BankCode.values())
+			.map(BankRes::from)
+			.collect(Collectors.toList());
+
+		return BaseResponse.success(banks);
+	}
+}

--- a/src/main/java/com/back/b2st/global/common/dto/BankRes.java
+++ b/src/main/java/com/back/b2st/global/common/dto/BankRes.java
@@ -1,0 +1,18 @@
+package com.back.b2st.global.common.dto;
+
+import com.back.b2st.global.common.BankCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BankRes {
+
+	private String code; // 서버
+	private String name; // 화면 표시
+
+	public static BankRes from(BankCode bankCode) {
+		return new BankRes(bankCode.getCode(), bankCode.getDescription());
+	}
+}

--- a/src/main/java/com/back/b2st/security/SecurityConfig.java
+++ b/src/main/java/com/back/b2st/security/SecurityConfig.java
@@ -39,7 +39,7 @@ public class SecurityConfig {
 
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers(
-					"/members/signup", "/auth/**", "/h2-console/**", "/error",
+					"/members/signup", "/auth/**", "/h2-console/**", "/error", "/common/**",
 					"/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html"    // Swagger
 				).permitAll()
 				.anyRequest().authenticated()

--- a/src/test/java/com/back/b2st/B2stApplicationTests.java
+++ b/src/test/java/com/back/b2st/B2stApplicationTests.java
@@ -2,8 +2,10 @@ package com.back.b2st;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class B2stApplicationTests {
 
 	@Test

--- a/src/test/java/com/back/b2st/domain/member/service/RefundAccountServiceTest.java
+++ b/src/test/java/com/back/b2st/domain/member/service/RefundAccountServiceTest.java
@@ -1,0 +1,114 @@
+package com.back.b2st.domain.member.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.back.b2st.domain.member.dto.RefundAccountReq;
+import com.back.b2st.domain.member.dto.RefundAccountRes;
+import com.back.b2st.domain.member.entity.Member;
+import com.back.b2st.domain.member.entity.RefundAccount;
+import com.back.b2st.domain.member.repository.MemberRepository;
+import com.back.b2st.domain.member.repository.RefundAccountRepository;
+import com.back.b2st.global.common.BankCode;
+
+@ExtendWith(MockitoExtension.class)
+public class RefundAccountServiceTest {
+
+	@InjectMocks
+	private RefundAccountService refundAccountService;
+
+	@Mock
+	private RefundAccountRepository refundAccountRepository;
+
+	@Mock
+	private MemberRepository memberRepository;
+
+	@Test
+	@DisplayName("계좌 신규 등록 성공")
+	void saveAccount_create_success() {
+		// given
+		Long memberId = 1L;
+		RefundAccountReq request = RefundAccountReq.builder()
+			.bankCode(BankCode.KB)
+			.accountNumber("1234")
+			.holderName("홍길동")
+			.build();
+
+		Member member = Member.builder().build();
+
+		given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+		given(refundAccountRepository.findByMember(member)).willReturn(Optional.empty()); // 기존 계좌 없음
+
+		// when
+		refundAccountService.saveAccount(memberId, request);
+
+		// then
+		verify(refundAccountRepository).save(any(RefundAccount.class));
+	}
+
+	@Test
+	@DisplayName("계좌 수정 성공")
+	void saveAccount_update_success() {
+		// given
+		Long memberId = 1L;
+		RefundAccountReq request = RefundAccountReq.builder()
+			.bankCode(BankCode.SHINHAN)
+			.accountNumber("5678")
+			.holderName("홍길동")
+			.build();
+
+		Member member = Member.builder().build();
+		// 기존 계좌 존재 (국민/1234)
+		RefundAccount existingAccount = RefundAccount.builder()
+			.member(member)
+			.bankCode(BankCode.KB)
+			.accountNumber("1234")
+			.holderName("홍길동")
+			.build();
+
+		given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+		given(refundAccountRepository.findByMember(member)).willReturn(Optional.of(existingAccount));
+
+		// when
+		refundAccountService.saveAccount(memberId, request);
+
+		// then
+		// 객체 내부 값이 변경되었는지 확인 (Dirty Checking)
+		assertThat(existingAccount.getBankCode()).isEqualTo(BankCode.SHINHAN);
+		assertThat(existingAccount.getAccountNumber()).isEqualTo("5678");
+	}
+
+	@Test
+	@DisplayName("계좌 조회 성공")
+	void getAccount_success() {
+		// given
+		Long memberId = 1L;
+		Member member = Member.builder().build();
+		RefundAccount account = RefundAccount.builder()
+			.member(member)
+			.bankCode(BankCode.KB)
+			.accountNumber("1234")
+			.holderName("홍길동")
+			.build();
+
+		given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+		given(refundAccountRepository.findByMember(member)).willReturn(Optional.of(account));
+
+		// when
+		RefundAccountRes response = refundAccountService.getAccount(memberId);
+
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response.getAccountNumber()).isEqualTo("1234");
+	}
+}

--- a/src/test/java/com/back/b2st/global/common/controller/CommonControllerTest.java
+++ b/src/test/java/com/back/b2st/global/common/controller/CommonControllerTest.java
@@ -1,0 +1,40 @@
+package com.back.b2st.global.common.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.b2st.global.test.AbstractContainerBaseTest;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class CommonControllerTest extends AbstractContainerBaseTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("통합: 은행 목록 조회 성공 - Enum 데이터가 JSON으로 변환되는지")
+	void getBankList_success() throws Exception {
+		// when & then
+		mockMvc.perform(get("/common/banks")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data").isArray())
+			.andExpect(jsonPath("$.data[?(@.code == '004')].name").value("KB국민은행"))
+			.andExpect(jsonPath("$.data[?(@.code == '090')].name").value("카카오뱅크"));
+	}
+}


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 관련 이슈
- close #133 

</br>

## 작업 내용
- RefundAccount 엔티티
    - id, member, bankCode, accountNumber, holderName
    - req/res dto, repository, service, controller 작성
- 뱅크 코드 파일들의 경우, 특정 유저에 종속된 데이터가 아니라 공통적으로 존재하는 거라고 생각해서 global/common/에 구현
- 유닛, 통합 테스트 코드 작성

</br>

## 체크리스트
- [ ] 코딩 컨벤션 준수
- [ ] 불필요한 코드 제거
- [ ] 테스트 완료
