### PR TITLE
feat: Trade 도메인 Pessimistic Lock 구현

### DIFF
--- a/src/test/java/com/back/b2st/domain/trade/service/TradeRequestServiceTest.java
+++ b/src/test/java/com/back/b2st/domain/trade/service/TradeRequestServiceTest.java
@@ -382,7 +382,7 @@ class TradeRequestServiceTest {
 			.seatId(10L)
 			.build();
 
-		given(tradeRequestRepository.findById(tradeRequestId)).willReturn(Optional.of(tradeRequest));
+		given(entityManager.find(TradeRequest.class, tradeRequestId, LockModeType.PESSIMISTIC_WRITE)).willReturn(tradeRequest);
 		given(entityManager.find(Trade.class, trade.getId(), LockModeType.PESSIMISTIC_WRITE)).willReturn(trade);
 		given(tradeRequestRepository.findByTradeAndStatus(trade, TradeRequestStatus.ACCEPTED))
 			.willReturn(Collections.emptyList());
@@ -428,7 +428,7 @@ class TradeRequestServiceTest {
 			.requesterTicketId(10L)
 			.build();
 
-		given(tradeRequestRepository.findById(tradeRequestId)).willReturn(Optional.of(tradeRequest));
+		given(entityManager.find(TradeRequest.class, tradeRequestId, LockModeType.PESSIMISTIC_WRITE)).willReturn(tradeRequest);
 		given(entityManager.find(Trade.class, trade.getId(), LockModeType.PESSIMISTIC_WRITE)).willReturn(trade);
 
 		// when & then
@@ -464,7 +464,7 @@ class TradeRequestServiceTest {
 			.build();
 		tradeRequest.accept();
 
-		given(tradeRequestRepository.findById(tradeRequestId)).willReturn(Optional.of(tradeRequest));
+		given(entityManager.find(TradeRequest.class, tradeRequestId, LockModeType.PESSIMISTIC_WRITE)).willReturn(tradeRequest);
 		given(entityManager.find(Trade.class, trade.getId(), LockModeType.PESSIMISTIC_WRITE)).willReturn(trade);
 
 		// when & then
@@ -500,7 +500,7 @@ class TradeRequestServiceTest {
 			.requesterTicketId(10L)
 			.build();
 
-		given(tradeRequestRepository.findById(tradeRequestId)).willReturn(Optional.of(tradeRequest));
+		given(entityManager.find(TradeRequest.class, tradeRequestId, LockModeType.PESSIMISTIC_WRITE)).willReturn(tradeRequest);
 		given(entityManager.find(Trade.class, trade.getId(), LockModeType.PESSIMISTIC_WRITE)).willReturn(trade);
 
 		// when & then
@@ -542,7 +542,7 @@ class TradeRequestServiceTest {
 			.build();
 		acceptedRequest.accept();
 
-		given(tradeRequestRepository.findById(tradeRequestId)).willReturn(Optional.of(tradeRequest));
+		given(entityManager.find(TradeRequest.class, tradeRequestId, LockModeType.PESSIMISTIC_WRITE)).willReturn(tradeRequest);
 		given(entityManager.find(Trade.class, trade.getId(), LockModeType.PESSIMISTIC_WRITE)).willReturn(trade);
 		given(tradeRequestRepository.findByTradeAndStatus(trade, TradeRequestStatus.ACCEPTED))
 			.willReturn(List.of(acceptedRequest));
@@ -579,7 +579,8 @@ class TradeRequestServiceTest {
 			.requesterTicketId(10L)
 			.build();
 
-		given(tradeRequestRepository.findById(tradeRequestId)).willReturn(Optional.of(tradeRequest));
+		given(entityManager.find(TradeRequest.class, tradeRequestId, LockModeType.PESSIMISTIC_WRITE)).willReturn(tradeRequest);
+		given(entityManager.find(Trade.class, trade.getId(), LockModeType.PESSIMISTIC_WRITE)).willReturn(trade);
 
 		// when
 		tradeRequestService.rejectTradeRequest(tradeRequestId, memberId);
@@ -614,7 +615,8 @@ class TradeRequestServiceTest {
 			.requesterTicketId(10L)
 			.build();
 
-		given(tradeRequestRepository.findById(tradeRequestId)).willReturn(Optional.of(tradeRequest));
+		given(entityManager.find(TradeRequest.class, tradeRequestId, LockModeType.PESSIMISTIC_WRITE)).willReturn(tradeRequest);
+		given(entityManager.find(Trade.class, trade.getId(), LockModeType.PESSIMISTIC_WRITE)).willReturn(trade);
 
 		// when & then
 		assertThatThrownBy(() -> tradeRequestService.rejectTradeRequest(tradeRequestId, memberId))
@@ -649,7 +651,8 @@ class TradeRequestServiceTest {
 			.build();
 		tradeRequest.reject();
 
-		given(tradeRequestRepository.findById(tradeRequestId)).willReturn(Optional.of(tradeRequest));
+		given(entityManager.find(TradeRequest.class, tradeRequestId, LockModeType.PESSIMISTIC_WRITE)).willReturn(tradeRequest);
+		given(entityManager.find(Trade.class, trade.getId(), LockModeType.PESSIMISTIC_WRITE)).willReturn(trade);
 
 		// when & then
 		assertThatThrownBy(() -> tradeRequestService.rejectTradeRequest(tradeRequestId, memberId))
@@ -689,7 +692,7 @@ class TradeRequestServiceTest {
 			.seatId(1L)
 			.build();
 
-		given(tradeRequestRepository.findById(tradeRequestId)).willReturn(Optional.of(tradeRequest));
+		given(entityManager.find(TradeRequest.class, tradeRequestId, LockModeType.PESSIMISTIC_WRITE)).willReturn(tradeRequest);
 		given(entityManager.find(Trade.class, trade.getId(), LockModeType.PESSIMISTIC_WRITE)).willReturn(trade);
 		given(tradeRequestRepository.findByTradeAndStatus(trade, TradeRequestStatus.ACCEPTED))
 			.willReturn(Collections.emptyList());
@@ -751,7 +754,7 @@ class TradeRequestServiceTest {
 		statusField.setAccessible(true);
 		statusField.set(ownerTicket, TicketStatus.TRANSFERRED);
 
-		given(tradeRequestRepository.findById(tradeRequestId)).willReturn(Optional.of(tradeRequest));
+		given(entityManager.find(TradeRequest.class, tradeRequestId, LockModeType.PESSIMISTIC_WRITE)).willReturn(tradeRequest);
 		given(entityManager.find(Trade.class, trade.getId(), LockModeType.PESSIMISTIC_WRITE)).willReturn(trade);
 		given(tradeRequestRepository.findByTradeAndStatus(trade, TradeRequestStatus.ACCEPTED))
 			.willReturn(Collections.emptyList());


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 관련 이슈
- close #187 

</br>

## 작업 내용
Trade 도메인의 교환 신청 수락 과정에 Pessimistic Lock을 적용하여 동시성 문제를 해결
기존에는 Accept만 Trade 엔티티에 락을 걸었고, Reject는 락 없이 실행되어 동시성 문제 발생

 1. 이중 락 구조 도입
    - Accept/Reject 실행 시 TradeRequest → Trade 순서로 락 획득
    - 두 엔티티 모두 락을 걸어 동시 접근 완전 차단
  2. 락 적용 로직
  acceptTradeRequest() / rejectTradeRequest()
  ├─ 1. TradeRequest 락 획득 (PESSIMISTIC_WRITE)
  ├─ 2. Trade 락 획득 (PESSIMISTIC_WRITE)
  ├─ 3. 검증 로직 실행
  └─ 4. 상태 변경 (ACCEPTED or REJECTED)
  3. 동시성 테스트 추가
    - Accept와 Reject를 동시에 호출하여 하나만 성공하는지 검증
    - ExecutorService로 2개 스레드 동시 실행 → 1개 성공, 1개 실패 확인

</br>

## 체크리스트
- [ ] 코딩 컨벤션 준수
- [ ] 불필요한 코드 제거
- [ ] 테스트 완료
