### PR TITLE
feat: 예매 결제 취소 구현 및 양도 취소 금지

### DIFF
--- a/src/main/java/com/back/b2st/domain/payment/controller/PaymentCancelController.java
+++ b/src/main/java/com/back/b2st/domain/payment/controller/PaymentCancelController.java
@@ -32,7 +32,7 @@ public class PaymentCancelController {
 	@Operation(
 		summary = "결제 취소",
 		description = "완료된 결제를 취소합니다.\n\n"
-			+ "- 현재는 TRADE(티켓 거래) 도메인만 취소 후처리를 지원합니다."
+			+ "- 티켓 거래(TRADE) 결제는 취소/환불을 지원하지 않습니다."
 	)
 	@PostMapping("/{orderId}/cancel")
 	public ResponseEntity<BaseResponse<PaymentCancelRes>> cancel(

--- a/src/main/java/com/back/b2st/domain/payment/service/PaymentCancelService.java
+++ b/src/main/java/com/back/b2st/domain/payment/service/PaymentCancelService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.back.b2st.domain.payment.dto.request.PaymentCancelReq;
+import com.back.b2st.domain.payment.entity.DomainType;
 import com.back.b2st.domain.payment.entity.Payment;
 import com.back.b2st.domain.payment.entity.PaymentStatus;
 import com.back.b2st.domain.payment.error.PaymentErrorCode;
@@ -42,6 +43,12 @@ public class PaymentCancelService {
 		if (payment.getStatus() != PaymentStatus.DONE) {
 			throw new BusinessException(PaymentErrorCode.INVALID_STATUS,
 				"완료된 결제만 취소할 수 있습니다.");
+		}
+
+		// 5. 정책: 티켓 거래 결제는 취소/환불 미지원
+		if (payment.getDomainType() == DomainType.TRADE) {
+			throw new BusinessException(PaymentErrorCode.DOMAIN_NOT_PAYABLE,
+				"티켓 거래 결제는 취소/환불을 지원하지 않습니다.");
 		}
 
 		// 5. 도메인별 취소 처리 (티켓 복구, 거래 상태 변경 등)

--- a/src/main/java/com/back/b2st/domain/payment/service/ReservationPaymentHandler.java
+++ b/src/main/java/com/back/b2st/domain/payment/service/ReservationPaymentHandler.java
@@ -45,11 +45,12 @@ public class ReservationPaymentHandler implements PaymentDomainHandler {
 			throw new BusinessException(PaymentErrorCode.UNAUTHORIZED_PAYMENT_ACCESS);
 		}
 
-		if (reservation.getStatus() != ReservationStatus.PENDING) {
+		if (reservation.getStatus() != ReservationStatus.CREATED
+			&& reservation.getStatus() != ReservationStatus.PENDING) {
 			throw new BusinessException(PaymentErrorCode.DOMAIN_NOT_PAYABLE);
 		}
 
-		Long scheduleId = reservation.getPerformanceId();
+		Long scheduleId = reservation.getScheduleId();
 		Long seatId = reservation.getSeatId();
 
 		ScheduleSeat scheduleSeat = scheduleSeatRepository.findByScheduleIdAndSeatId(scheduleId, seatId)
@@ -72,4 +73,3 @@ public class ReservationPaymentHandler implements PaymentDomainHandler {
 		return new PaymentTarget(DomainType.RESERVATION, reservationId, expectedAmount);
 	}
 }
-

--- a/src/main/java/com/back/b2st/domain/payment/service/TradeCancelHandler.java
+++ b/src/main/java/com/back/b2st/domain/payment/service/TradeCancelHandler.java
@@ -1,34 +1,14 @@
 package com.back.b2st.domain.payment.service;
 
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.back.b2st.domain.payment.entity.DomainType;
 import com.back.b2st.domain.payment.entity.Payment;
 import com.back.b2st.domain.payment.error.PaymentErrorCode;
-import com.back.b2st.domain.ticket.entity.Ticket;
-import com.back.b2st.domain.ticket.entity.TicketStatus;
-import com.back.b2st.domain.ticket.repository.TicketRepository;
-import com.back.b2st.domain.ticket.service.TicketService;
-import com.back.b2st.domain.trade.entity.Trade;
-import com.back.b2st.domain.trade.entity.TradeStatus;
-import com.back.b2st.domain.trade.error.TradeErrorCode;
 import com.back.b2st.global.error.exception.BusinessException;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.LockModeType;
-import jakarta.persistence.PersistenceContext;
-import lombok.RequiredArgsConstructor;
-
 @Component
-@RequiredArgsConstructor
 public class TradeCancelHandler implements PaymentCancelHandler {
-
-	@PersistenceContext
-	private EntityManager entityManager;
-
-	private final TicketService ticketService;
-	private final TicketRepository ticketRepository;
 
 	@Override
 	public boolean supports(DomainType domainType) {
@@ -36,48 +16,8 @@ public class TradeCancelHandler implements PaymentCancelHandler {
 	}
 
 	@Override
-	@Transactional
 	public void handleCancel(Payment payment) {
-		// 1. Trade 조회 및 락 획득
-		Trade trade = entityManager.find(Trade.class, payment.getDomainId(),
-			LockModeType.PESSIMISTIC_WRITE);
-		if (trade == null) {
-			throw new BusinessException(TradeErrorCode.TRADE_NOT_FOUND);
-		}
-
-		// 2. 이미 취소된 경우 멱등성 처리
-		if (trade.getStatus() == TradeStatus.CANCELLED) {
-			return;
-		}
-
-		// 3. COMPLETED 상태만 취소 가능
-		if (trade.getStatus() != TradeStatus.COMPLETED) {
-			throw new BusinessException(PaymentErrorCode.INVALID_STATUS,
-				"완료된 거래만 취소할 수 있습니다.");
-		}
-
-		// 4. 원본(판매자) 티켓 조회
-		Ticket originalTicket = ticketService.getTicketById(trade.getTicketId());
-		Long reservationId = originalTicket.getReservationId();
-		Long seatId = originalTicket.getSeatId();
-
-		// 5. 구매자 티켓 삭제 (양도받은 티켓)
-		Long buyerId = payment.getMemberId();
-		ticketRepository.findByReservationIdAndMemberIdAndSeatId(reservationId, buyerId, seatId)
-			.ifPresent(ticket -> {
-				if (ticket.getStatus() != TicketStatus.ISSUED) {
-					throw new BusinessException(PaymentErrorCode.INVALID_STATUS,
-						"사용/변경된 티켓은 결제 취소할 수 없습니다.");
-				}
-				ticketRepository.delete(ticket);
-			});
-
-		// 6. 판매자 티켓 복구 (TRANSFERRED → ISSUED)
-		if (originalTicket.getStatus() == TicketStatus.TRANSFERRED) {
-			ticketService.restoreTicket(originalTicket.getId());
-		}
-
-		// 7. 거래 상태를 CANCELLED로 변경
-		trade.cancel();
+		throw new BusinessException(PaymentErrorCode.DOMAIN_NOT_PAYABLE,
+			"티켓 거래 결제는 취소/환불을 지원하지 않습니다.");
 	}
 }

--- a/src/main/java/com/back/b2st/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/back/b2st/domain/reservation/repository/ReservationRepository.java
@@ -1,11 +1,17 @@
 package com.back.b2st.domain.reservation.repository;
 
 import java.util.List;
+import java.util.Optional;
 
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.back.b2st.domain.reservation.entity.Reservation;
+
+import jakarta.persistence.LockModeType;
 
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long>, ReservationRepositoryCustom {
@@ -15,4 +21,8 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long>,
 
 	/** === 좌석 중복 예매 방지 === */
 	boolean existsByScheduleIdAndSeatId(Long scheduleId, Long seatId);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT r FROM Reservation r WHERE r.id = :reservationId")
+	Optional<Reservation> findByIdWithLock(@Param("reservationId") Long reservationId);
 }

--- a/src/main/java/com/back/b2st/domain/scheduleseat/repository/ScheduleSeatRepository.java
+++ b/src/main/java/com/back/b2st/domain/scheduleseat/repository/ScheduleSeatRepository.java
@@ -5,12 +5,15 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.back.b2st.domain.scheduleseat.entity.ScheduleSeat;
 import com.back.b2st.domain.scheduleseat.entity.SeatStatus;
+
+import jakarta.persistence.LockModeType;
 
 public interface ScheduleSeatRepository extends JpaRepository<ScheduleSeat, Long>, ScheduleSeatRepositoryCustom {
 
@@ -19,6 +22,13 @@ public interface ScheduleSeatRepository extends JpaRepository<ScheduleSeat, Long
 
 	/* scheduleId + seatId 로 특정 좌석 조회 */
 	Optional<ScheduleSeat> findByScheduleIdAndSeatId(Long scheduleId, Long seatId);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT s FROM ScheduleSeat s WHERE s.scheduleId = :scheduleId AND s.seatId = :seatId")
+	Optional<ScheduleSeat> findByScheduleIdAndSeatIdWithLock(
+		@Param("scheduleId") Long scheduleId,
+		@Param("seatId") Long seatId
+	);
 
 	/* 특정 회차에서 특정 상태의 좌석 조회 (예: AVAILABLE 좌석만) */
 	List<ScheduleSeat> findByScheduleIdAndStatus(Long scheduleId, SeatStatus status);

--- a/src/test/java/com/back/b2st/domain/payment/service/PaymentPrepareServiceTest.java
+++ b/src/test/java/com/back/b2st/domain/payment/service/PaymentPrepareServiceTest.java
@@ -238,4 +238,3 @@ class PaymentPrepareServiceTest {
 		}
 	}
 }
-

--- a/src/test/java/com/back/b2st/domain/payment/service/ReservationPaymentHandlerTest.java
+++ b/src/test/java/com/back/b2st/domain/payment/service/ReservationPaymentHandlerTest.java
@@ -68,7 +68,7 @@ class ReservationPaymentHandlerTest {
 		Long expectedPrice = 50000L;
 
 		Reservation reservation = createReservation(reservationId, memberId, scheduleId, seatId,
-			ReservationStatus.PENDING);
+			ReservationStatus.CREATED);
 		ScheduleSeat scheduleSeat = createScheduleSeat(scheduleId, seatId, SeatStatus.HOLD);
 		PerformanceSchedule schedule = createPerformanceSchedule(scheduleId, performanceId);
 		SeatGrade seatGrade = createSeatGrade(performanceId, seatId, expectedPrice);


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 관련 이슈
- close #301 

</br>

## 작업 내용
- 예매 결제 취소 기능 추가 및 양도 결제 취소 금지 정책 적용

### 변경사항
  1. 예매 결제 취소 구현
  - 결제 취소 시 예매 취소 + 좌석 반납 + 티켓 삭제 자동 처리
  - 동시성 제어 (비관적 락)

  2. 양도 결제 취소 금지
  - 사용자간 거래(C2C)는 환불/취소 불가


</br>

## 체크리스트
- [ ] 코딩 컨벤션 준수
- [ ] 불필요한 코드 제거
- [ ] 테스트 완료
