### PR TITLE
feat: 양도 구매 내역 조회 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ src/main/generated/
 
 ### custom ###
 src/main/resources/application-secret.yml
+
+# local / sensitive files
+*.pem

--- a/src/main/java/com/back/b2st/domain/trade/controller/TradeHistoryController.java
+++ b/src/main/java/com/back/b2st/domain/trade/controller/TradeHistoryController.java
@@ -1,0 +1,49 @@
+package com.back.b2st.domain.trade.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.back.b2st.domain.trade.dto.response.TransferTradeHistoryRes;
+import com.back.b2st.domain.trade.service.TradeHistoryService;
+import com.back.b2st.global.annotation.CurrentUser;
+import com.back.b2st.global.common.BaseResponse;
+import com.back.b2st.security.UserPrincipal;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "TradeHistory", description = "양도 구매/판매 내역 API")
+@RestController
+@RequestMapping("/api/mypage/trades/transfers")
+@RequiredArgsConstructor
+public class TradeHistoryController {
+
+	private final TradeHistoryService tradeHistoryService;
+
+	@Operation(
+		summary = "내 양도 구매 내역 조회",
+		description = "내가 구매한 양도(TRANSFER) 완료 내역을 조회합니다. 상대방 개인정보는 제공하지 않습니다."
+	)
+	@GetMapping("/purchases")
+	public BaseResponse<List<TransferTradeHistoryRes>> getMyTransferPurchases(
+		@CurrentUser UserPrincipal userPrincipal
+	) {
+		return BaseResponse.success(tradeHistoryService.getMyTransferPurchases(userPrincipal.getId()));
+	}
+
+	@Operation(
+		summary = "내 양도 판매 내역 조회",
+		description = "내가 판매한 양도(TRANSFER) 완료 내역을 조회합니다. 상대방 개인정보는 제공하지 않습니다."
+	)
+	@GetMapping("/sales")
+	public BaseResponse<List<TransferTradeHistoryRes>> getMyTransferSales(
+		@CurrentUser UserPrincipal userPrincipal
+	) {
+		return BaseResponse.success(tradeHistoryService.getMyTransferSales(userPrincipal.getId()));
+	}
+}
+

--- a/src/main/java/com/back/b2st/domain/trade/dto/response/TransferTradeHistoryRes.java
+++ b/src/main/java/com/back/b2st/domain/trade/dto/response/TransferTradeHistoryRes.java
@@ -1,0 +1,41 @@
+package com.back.b2st.domain.trade.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.back.b2st.domain.trade.entity.Trade;
+import com.back.b2st.domain.trade.entity.TradeStatus;
+import com.back.b2st.domain.trade.entity.TradeType;
+
+public record TransferTradeHistoryRes(
+	Long tradeId,
+	TradeType type,
+	TradeStatus status,
+	Integer price,
+	Long performanceId,
+	Long scheduleId,
+	Integer totalCount,
+	String section,
+	String row,
+	String seatNumber,
+	LocalDateTime purchasedAt,
+	LocalDateTime createdAt
+) {
+
+	public static TransferTradeHistoryRes from(Trade trade) {
+		return new TransferTradeHistoryRes(
+			trade.getId(),
+			trade.getType(),
+			trade.getStatus(),
+			trade.getPrice(),
+			trade.getPerformanceId(),
+			trade.getScheduleId(),
+			trade.getTotalCount(),
+			trade.getSection(),
+			trade.getRow(),
+			trade.getSeatNumber(),
+			trade.getPurchasedAt(),
+			trade.getCreatedAt()
+		);
+	}
+}
+

--- a/src/main/java/com/back/b2st/domain/trade/entity/Trade.java
+++ b/src/main/java/com/back/b2st/domain/trade/entity/Trade.java
@@ -3,6 +3,8 @@ package com.back.b2st.domain.trade.entity;
 import java.time.LocalDateTime;
 
 import com.back.b2st.global.jpa.entity.BaseEntity;
+import com.back.b2st.global.error.exception.BusinessException;
+import com.back.b2st.domain.trade.error.TradeErrorCode;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -21,13 +23,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "trade",
+	@Table(name = "trade",
 	uniqueConstraints = @UniqueConstraint(
 		name = "uk_trade_ticket_active",
 		columnNames = {"ticket_id", "status"}
 	),
 	indexes = {
 		@Index(name = "idx_trade_member_status", columnList = "member_id, status"),
+		@Index(name = "idx_trade_buyer_status", columnList = "buyer_id, status"),
 		@Index(name = "idx_trade_performance", columnList = "performance_id, status"),
 		@Index(name = "idx_trade_type_status_created", columnList = "type, status, create_at"),
 		@Index(name = "idx_trade_status_created", columnList = "status, create_at"),
@@ -50,6 +53,9 @@ public class Trade extends BaseEntity {
 
 	@Column(name = "member_id", nullable = false)
 	private Long memberId;
+
+	@Column(name = "buyer_id")
+	private Long buyerId;
 
 	@Column(name = "performance_id", nullable = false)
 	private Long performanceId;
@@ -86,6 +92,9 @@ public class Trade extends BaseEntity {
 	@Column(name = "deleted_at")
 	private LocalDateTime deletedAt;
 
+	@Column(name = "purchased_at")
+	private LocalDateTime purchasedAt;
+
 	@Builder
 	public Trade(Long memberId, Long performanceId, Long scheduleId, Long ticketId,
 		TradeType type, Integer price, Integer totalCount,
@@ -109,6 +118,27 @@ public class Trade extends BaseEntity {
 
 	public void complete() {
 		this.status = TradeStatus.COMPLETED;
+	}
+
+	public void completeTransfer(Long buyerId, LocalDateTime purchasedAt) {
+		if (this.buyerId != null && !this.buyerId.equals(buyerId)) {
+			throw new BusinessException(TradeErrorCode.UNAUTHORIZED_TRADE_ACCESS, "buyerId mismatch");
+		}
+		this.buyerId = buyerId;
+		this.purchasedAt = purchasedAt;
+		this.status = TradeStatus.COMPLETED;
+	}
+
+	public void ensureBuyer(Long buyerId, LocalDateTime purchasedAt) {
+		if (this.buyerId == null) {
+			this.buyerId = buyerId;
+		}
+		if (!this.buyerId.equals(buyerId)) {
+			throw new BusinessException(TradeErrorCode.UNAUTHORIZED_TRADE_ACCESS, "buyerId mismatch");
+		}
+		if (this.purchasedAt == null) {
+			this.purchasedAt = purchasedAt;
+		}
 	}
 
 	public void cancel() {

--- a/src/main/java/com/back/b2st/domain/trade/repository/TradeRepository.java
+++ b/src/main/java/com/back/b2st/domain/trade/repository/TradeRepository.java
@@ -1,5 +1,7 @@
 package com.back.b2st.domain.trade.repository;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,4 +19,8 @@ public interface TradeRepository extends JpaRepository<Trade, Long> {
 	Page<Trade> findAllByType(TradeType type, Pageable pageable);
 
 	Page<Trade> findAllByTypeAndStatus(TradeType type, TradeStatus status, Pageable pageable);
+
+	List<Trade> findAllByBuyerIdAndTypeAndStatusOrderByPurchasedAtDesc(Long buyerId, TradeType type, TradeStatus status);
+
+	List<Trade> findAllByMemberIdAndTypeAndStatusOrderByPurchasedAtDesc(Long memberId, TradeType type, TradeStatus status);
 }

--- a/src/main/java/com/back/b2st/domain/trade/service/TradeHistoryService.java
+++ b/src/main/java/com/back/b2st/domain/trade/service/TradeHistoryService.java
@@ -1,0 +1,45 @@
+package com.back.b2st.domain.trade.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.b2st.domain.trade.dto.response.TransferTradeHistoryRes;
+import com.back.b2st.domain.trade.entity.Trade;
+import com.back.b2st.domain.trade.entity.TradeStatus;
+import com.back.b2st.domain.trade.entity.TradeType;
+import com.back.b2st.domain.trade.repository.TradeRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TradeHistoryService {
+
+	private final TradeRepository tradeRepository;
+
+	public List<TransferTradeHistoryRes> getMyTransferPurchases(Long memberId) {
+		List<Trade> trades = tradeRepository.findAllByBuyerIdAndTypeAndStatusOrderByPurchasedAtDesc(
+			memberId,
+			TradeType.TRANSFER,
+			TradeStatus.COMPLETED
+		);
+		return trades.stream()
+			.map(TransferTradeHistoryRes::from)
+			.toList();
+	}
+
+	public List<TransferTradeHistoryRes> getMyTransferSales(Long memberId) {
+		List<Trade> trades = tradeRepository.findAllByMemberIdAndTypeAndStatusOrderByPurchasedAtDesc(
+			memberId,
+			TradeType.TRANSFER,
+			TradeStatus.COMPLETED
+		);
+		return trades.stream()
+			.map(TransferTradeHistoryRes::from)
+			.toList();
+	}
+}
+

--- a/src/test/java/com/back/b2st/domain/payment/service/TradePaymentFinalizerTest.java
+++ b/src/test/java/com/back/b2st/domain/payment/service/TradePaymentFinalizerTest.java
@@ -362,6 +362,8 @@ class TradePaymentFinalizerTest {
 		// then - 거래가 완료됨
 		Trade result = tradeRepository.findById(savedTrade.getId()).orElseThrow();
 		assertThat(result.getStatus()).isEqualTo(TradeStatus.COMPLETED);
+		assertThat(result.getBuyerId()).isEqualTo(buyerId);
+		assertThat(result.getPurchasedAt()).isNotNull();
 
 		// then - 판매자 티켓이 TRANSFERRED로 변경됨
 		Ticket updatedSellerTicket = ticketRepository.findById(sellerTicket.getId()).orElseThrow();
@@ -423,6 +425,8 @@ class TradePaymentFinalizerTest {
 		// then - 거래는 여전히 COMPLETED
 		Trade result = tradeRepository.findById(savedTrade.getId()).orElseThrow();
 		assertThat(result.getStatus()).isEqualTo(TradeStatus.COMPLETED);
+		assertThat(result.getBuyerId()).isEqualTo(buyerId);
+		assertThat(result.getPurchasedAt()).isNotNull();
 	}
 
 	@Test
@@ -480,5 +484,9 @@ class TradePaymentFinalizerTest {
 		Ticket buyerTicket = ticketRepository.findByReservationIdAndMemberIdAndSeatId(1L, buyerId, 1L)
 			.orElseThrow();
 		assertThat(buyerTicket.getStatus()).isEqualTo(TicketStatus.ISSUED);
+
+		Trade result = tradeRepository.findById(savedTrade.getId()).orElseThrow();
+		assertThat(result.getBuyerId()).isEqualTo(buyerId);
+		assertThat(result.getPurchasedAt()).isNotNull();
 	}
 }

--- a/src/test/java/com/back/b2st/domain/trade/service/TradeHistoryServiceTest.java
+++ b/src/test/java/com/back/b2st/domain/trade/service/TradeHistoryServiceTest.java
@@ -1,0 +1,147 @@
+package com.back.b2st.domain.trade.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.back.b2st.domain.trade.dto.response.TransferTradeHistoryRes;
+import com.back.b2st.domain.trade.entity.Trade;
+import com.back.b2st.domain.trade.entity.TradeStatus;
+import com.back.b2st.domain.trade.entity.TradeType;
+import com.back.b2st.domain.trade.repository.TradeRepository;
+
+@ExtendWith(MockitoExtension.class)
+class TradeHistoryServiceTest {
+
+	@InjectMocks
+	private TradeHistoryService tradeHistoryService;
+
+	@Mock
+	private TradeRepository tradeRepository;
+
+	@Test
+	@DisplayName("내 양도 구매 내역 조회 - buyerId 기준 조회 및 DTO 매핑")
+	void getMyTransferPurchases_success() {
+		// given
+		Long memberId = 10L;
+		LocalDateTime purchasedAt = LocalDateTime.of(2025, 12, 22, 12, 0);
+		LocalDateTime createdAt = LocalDateTime.of(2025, 12, 22, 11, 0);
+
+		Trade trade = Trade.builder()
+			.memberId(1L)
+			.performanceId(100L)
+			.scheduleId(200L)
+			.ticketId(300L)
+			.type(TradeType.TRANSFER)
+			.price(15000)
+			.totalCount(1)
+			.section("A")
+			.row("5열")
+			.seatNumber("12석")
+			.build();
+		ReflectionTestUtils.setField(trade, "id", 999L);
+		ReflectionTestUtils.setField(trade, "buyerId", memberId);
+		ReflectionTestUtils.setField(trade, "purchasedAt", purchasedAt);
+		ReflectionTestUtils.setField(trade, "createdAt", createdAt);
+		trade.complete();
+
+		given(tradeRepository.findAllByBuyerIdAndTypeAndStatusOrderByPurchasedAtDesc(
+			memberId, TradeType.TRANSFER, TradeStatus.COMPLETED
+		)).willReturn(List.of(trade));
+
+		// when
+		List<TransferTradeHistoryRes> result = tradeHistoryService.getMyTransferPurchases(memberId);
+
+		// then
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0).tradeId()).isEqualTo(999L);
+		assertThat(result.get(0).type()).isEqualTo(TradeType.TRANSFER);
+		assertThat(result.get(0).status()).isEqualTo(TradeStatus.COMPLETED);
+		assertThat(result.get(0).price()).isEqualTo(15000);
+		assertThat(result.get(0).performanceId()).isEqualTo(100L);
+		assertThat(result.get(0).scheduleId()).isEqualTo(200L);
+		assertThat(result.get(0).totalCount()).isEqualTo(1);
+		assertThat(result.get(0).section()).isEqualTo("A");
+		assertThat(result.get(0).row()).isEqualTo("5열");
+		assertThat(result.get(0).seatNumber()).isEqualTo("12석");
+		assertThat(result.get(0).purchasedAt()).isEqualTo(purchasedAt);
+		assertThat(result.get(0).createdAt()).isEqualTo(createdAt);
+
+		verify(tradeRepository).findAllByBuyerIdAndTypeAndStatusOrderByPurchasedAtDesc(
+			memberId, TradeType.TRANSFER, TradeStatus.COMPLETED
+		);
+	}
+
+	@Test
+	@DisplayName("내 양도 판매 내역 조회 - memberId 기준 조회 및 DTO 매핑")
+	void getMyTransferSales_success() {
+		// given
+		Long memberId = 10L;
+		LocalDateTime purchasedAt = LocalDateTime.of(2025, 12, 22, 12, 0);
+		LocalDateTime createdAt = LocalDateTime.of(2025, 12, 22, 11, 0);
+
+		Trade trade = Trade.builder()
+			.memberId(memberId)
+			.performanceId(100L)
+			.scheduleId(200L)
+			.ticketId(300L)
+			.type(TradeType.TRANSFER)
+			.price(15000)
+			.totalCount(1)
+			.section("A")
+			.row("5열")
+			.seatNumber("12석")
+			.build();
+		ReflectionTestUtils.setField(trade, "id", 999L);
+		ReflectionTestUtils.setField(trade, "buyerId", 20L);
+		ReflectionTestUtils.setField(trade, "purchasedAt", purchasedAt);
+		ReflectionTestUtils.setField(trade, "createdAt", createdAt);
+		trade.complete();
+
+		given(tradeRepository.findAllByMemberIdAndTypeAndStatusOrderByPurchasedAtDesc(
+			memberId, TradeType.TRANSFER, TradeStatus.COMPLETED
+		)).willReturn(List.of(trade));
+
+		// when
+		List<TransferTradeHistoryRes> result = tradeHistoryService.getMyTransferSales(memberId);
+
+		// then
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0).tradeId()).isEqualTo(999L);
+		assertThat(result.get(0).type()).isEqualTo(TradeType.TRANSFER);
+		assertThat(result.get(0).status()).isEqualTo(TradeStatus.COMPLETED);
+		assertThat(result.get(0).price()).isEqualTo(15000);
+		assertThat(result.get(0).performanceId()).isEqualTo(100L);
+		assertThat(result.get(0).scheduleId()).isEqualTo(200L);
+		assertThat(result.get(0).totalCount()).isEqualTo(1);
+		assertThat(result.get(0).section()).isEqualTo("A");
+		assertThat(result.get(0).row()).isEqualTo("5열");
+		assertThat(result.get(0).seatNumber()).isEqualTo("12석");
+		assertThat(result.get(0).purchasedAt()).isEqualTo(purchasedAt);
+		assertThat(result.get(0).createdAt()).isEqualTo(createdAt);
+
+		verify(tradeRepository).findAllByMemberIdAndTypeAndStatusOrderByPurchasedAtDesc(
+			memberId, TradeType.TRANSFER, TradeStatus.COMPLETED
+		);
+	}
+
+	@Test
+	@DisplayName("양도 구매/판매 내역 응답은 개인정보(buyerId/memberId)를 포함하지 않는다")
+	void transferTradeHistoryRes_noPiiComponents() {
+		List<String> componentNames = Arrays.stream(TransferTradeHistoryRes.class.getRecordComponents())
+			.map(component -> component.getName())
+			.toList();
+		assertThat(componentNames).doesNotContain("buyerId", "memberId", "sellerId", "nickname", "name");
+	}
+}


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 관련 이슈
- close #307 

</br>

## 작업 내용

- 결제 완료 시 양도 거래에 구매자/구매시각 내부 기록 저장
   - Trade에 buyerId, purchasedAt 추가
   - 멱등 처리 시에도 buyer 기록 일관성 보장
- 마이페이지 양도 내역 API 추가(PII 0 노출)
   - GET /api/mypage/trades/transfers/purchases : 내 양도 구매 내역
   - GET /api/mypage/trades/transfers/sales : 내 양도 판매 내역
   - 응답 DTO는 상대방 정보/식별자 필드 자체가 없음
- Repository/Service 추가로 구매/판매 내역 조회 분리
- 예외 처리 개선: buyer mismatch 상황을 500 대신 도메인 예외로 처리
- 테스트 추가/보강
   - 결제 finalize 시 buyerId/purchasedAt 저장 검증
   - TradeHistoryService 매핑/PII 미포함 검증

### 비고
buyerId는 내부 조회용이며 API 응답으로 노출하지 않음

</br>

## 체크리스트
- [ ] 코딩 컨벤션 준수
- [ ] 불필요한 코드 제거
- [ ] 테스트 완료
