### PR TITLE
refactor: 예매 결제 실패 시 FAILED 연동

### DIFF
--- a/src/main/java/com/back/b2st/domain/payment/controller/PaymentFailController.java
+++ b/src/main/java/com/back/b2st/domain/payment/controller/PaymentFailController.java
@@ -1,0 +1,38 @@
+package com.back.b2st.domain.payment.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.back.b2st.domain.payment.dto.request.PaymentFailReq;
+import com.back.b2st.domain.payment.dto.response.PaymentFailRes;
+import com.back.b2st.domain.payment.entity.Payment;
+import com.back.b2st.domain.payment.service.PaymentFailService;
+import com.back.b2st.global.annotation.CurrentUser;
+import com.back.b2st.global.common.BaseResponse;
+import com.back.b2st.security.UserPrincipal;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/payments")
+public class PaymentFailController {
+
+	private final PaymentFailService paymentFailService;
+
+	@PostMapping("/{orderId}/fail")
+	public ResponseEntity<BaseResponse<PaymentFailRes>> fail(
+		@PathVariable("orderId") String orderId,
+		@Valid @RequestBody PaymentFailReq request,
+		@CurrentUser UserPrincipal user
+	) {
+		Payment payment = paymentFailService.fail(user.getId(), orderId, request.reason());
+		return ResponseEntity.ok(BaseResponse.success(PaymentFailRes.from(payment)));
+	}
+}
+

--- a/src/main/java/com/back/b2st/domain/payment/dto/request/PaymentFailReq.java
+++ b/src/main/java/com/back/b2st/domain/payment/dto/request/PaymentFailReq.java
@@ -1,0 +1,9 @@
+package com.back.b2st.domain.payment.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PaymentFailReq(
+	@NotBlank String reason
+) {
+}
+

--- a/src/main/java/com/back/b2st/domain/payment/dto/response/PaymentFailRes.java
+++ b/src/main/java/com/back/b2st/domain/payment/dto/response/PaymentFailRes.java
@@ -1,0 +1,21 @@
+package com.back.b2st.domain.payment.dto.response;
+
+import com.back.b2st.domain.payment.entity.Payment;
+import com.back.b2st.domain.payment.entity.PaymentStatus;
+
+public record PaymentFailRes(
+	String orderId,
+	Long amount,
+	PaymentStatus status,
+	String failureReason
+) {
+	public static PaymentFailRes from(Payment payment) {
+		return new PaymentFailRes(
+			payment.getOrderId(),
+			payment.getAmount(),
+			payment.getStatus(),
+			payment.getFailureReason()
+		);
+	}
+}
+

--- a/src/main/java/com/back/b2st/domain/payment/service/PaymentFailService.java
+++ b/src/main/java/com/back/b2st/domain/payment/service/PaymentFailService.java
@@ -1,0 +1,59 @@
+package com.back.b2st.domain.payment.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.b2st.domain.payment.entity.DomainType;
+import com.back.b2st.domain.payment.entity.Payment;
+import com.back.b2st.domain.payment.entity.PaymentStatus;
+import com.back.b2st.domain.payment.error.PaymentErrorCode;
+import com.back.b2st.domain.payment.repository.PaymentRepository;
+import com.back.b2st.domain.reservation.service.ReservationService;
+import com.back.b2st.global.error.exception.BusinessException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentFailService {
+
+	private final PaymentRepository paymentRepository;
+	private final ReservationService reservationService;
+
+	@Transactional
+	public Payment fail(Long memberId, String orderId, String reason) {
+		Payment payment = paymentRepository.findByOrderId(orderId)
+			.orElseThrow(() -> new BusinessException(PaymentErrorCode.NOT_FOUND));
+
+		validateOwner(payment, memberId);
+
+		// 멱등: 이미 실패 처리된 경우에도 도메인 후처리를 재시도할 수 있도록 허용
+		if (payment.getStatus() == PaymentStatus.FAILED) {
+			handleDomainFailure(payment);
+			return payment;
+		}
+
+		// READY에서만 FAILED로 전이 가능 (Payment.validateTransition 내에서도 방어)
+		if (payment.getStatus() != PaymentStatus.READY) {
+			throw new BusinessException(PaymentErrorCode.INVALID_STATUS, "결제 실패 처리가 불가능한 상태입니다.");
+		}
+
+		payment.fail(reason);
+		handleDomainFailure(payment);
+
+		return payment;
+	}
+
+	private void handleDomainFailure(Payment payment) {
+		if (payment.getDomainType() == DomainType.RESERVATION) {
+			reservationService.failReservation(payment.getDomainId());
+		}
+	}
+
+	private void validateOwner(Payment payment, Long memberId) {
+		if (!payment.getMemberId().equals(memberId)) {
+			throw new BusinessException(PaymentErrorCode.UNAUTHORIZED_PAYMENT_ACCESS);
+		}
+	}
+}
+

--- a/src/test/java/com/back/b2st/domain/payment/service/PaymentFailServiceTest.java
+++ b/src/test/java/com/back/b2st/domain/payment/service/PaymentFailServiceTest.java
@@ -1,0 +1,139 @@
+package com.back.b2st.domain.payment.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.back.b2st.domain.payment.entity.DomainType;
+import com.back.b2st.domain.payment.entity.Payment;
+import com.back.b2st.domain.payment.entity.PaymentMethod;
+import com.back.b2st.domain.payment.entity.PaymentStatus;
+import com.back.b2st.domain.payment.error.PaymentErrorCode;
+import com.back.b2st.domain.payment.repository.PaymentRepository;
+import com.back.b2st.domain.reservation.service.ReservationService;
+import com.back.b2st.global.error.exception.BusinessException;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentFailServiceTest {
+
+	@Mock
+	private PaymentRepository paymentRepository;
+
+	@Mock
+	private ReservationService reservationService;
+
+	@InjectMocks
+	private PaymentFailService paymentFailService;
+
+	@Test
+	void fail_marksPaymentFailed_andCallsReservationFail() {
+		String orderId = "ORDER-1";
+		Long memberId = 1L;
+		Long reservationId = 10L;
+		Long amount = 15000L;
+		String reason = "user canceled";
+
+		Payment payment = Payment.builder()
+			.orderId(orderId)
+			.memberId(memberId)
+			.domainType(DomainType.RESERVATION)
+			.domainId(reservationId)
+			.amount(amount)
+			.method(PaymentMethod.CARD)
+			.expiresAt(null)
+			.build();
+
+		when(paymentRepository.findByOrderId(orderId)).thenReturn(Optional.of(payment));
+
+		Payment failed = paymentFailService.fail(memberId, orderId, reason);
+
+		assertThat(failed.getStatus()).isEqualTo(PaymentStatus.FAILED);
+		assertThat(failed.getFailureReason()).isEqualTo(reason);
+		verify(reservationService).failReservation(reservationId);
+	}
+
+	@Test
+	void fail_isIdempotent_whenAlreadyFailed_stillCallsReservationFail() {
+		String orderId = "ORDER-2";
+		Long memberId = 1L;
+		Long reservationId = 11L;
+
+		Payment payment = Payment.builder()
+			.orderId(orderId)
+			.memberId(memberId)
+			.domainType(DomainType.RESERVATION)
+			.domainId(reservationId)
+			.amount(15000L)
+			.method(PaymentMethod.CARD)
+			.expiresAt(null)
+			.build();
+		payment.fail("first fail");
+
+		when(paymentRepository.findByOrderId(orderId)).thenReturn(Optional.of(payment));
+
+		Payment result = paymentFailService.fail(memberId, orderId, "second fail");
+
+		assertThat(result.getStatus()).isEqualTo(PaymentStatus.FAILED);
+		assertThat(result.getFailureReason()).isEqualTo("first fail");
+		verify(reservationService).failReservation(reservationId);
+	}
+
+	@Test
+	void fail_throwsInvalidStatus_whenPaymentNotReady() {
+		String orderId = "ORDER-3";
+		Long memberId = 1L;
+
+		Payment payment = Payment.builder()
+			.orderId(orderId)
+			.memberId(memberId)
+			.domainType(DomainType.RESERVATION)
+			.domainId(12L)
+			.amount(15000L)
+			.method(PaymentMethod.CARD)
+			.expiresAt(null)
+			.build();
+		payment.complete(LocalDateTime.now());
+
+		when(paymentRepository.findByOrderId(orderId)).thenReturn(Optional.of(payment));
+
+		assertThatThrownBy(() -> paymentFailService.fail(memberId, orderId, "any"))
+			.isInstanceOf(BusinessException.class)
+			.extracting(ex -> ((BusinessException)ex).getErrorCode())
+			.isEqualTo(PaymentErrorCode.INVALID_STATUS);
+	}
+
+	@Test
+	void fail_throwsUnauthorized_whenMemberDoesNotOwnPayment() {
+		String orderId = "ORDER-4";
+		Long ownerId = 1L;
+		Long requesterId = 2L;
+
+		Payment payment = Payment.builder()
+			.orderId(orderId)
+			.memberId(ownerId)
+			.domainType(DomainType.RESERVATION)
+			.domainId(13L)
+			.amount(15000L)
+			.method(PaymentMethod.CARD)
+			.expiresAt(null)
+			.build();
+
+		when(paymentRepository.findByOrderId(orderId)).thenReturn(Optional.of(payment));
+
+		assertThatThrownBy(() -> paymentFailService.fail(requesterId, orderId, "any"))
+			.isInstanceOf(BusinessException.class)
+			.extracting(ex -> ((BusinessException)ex).getErrorCode())
+			.isEqualTo(PaymentErrorCode.UNAUTHORIZED_PAYMENT_ACCESS);
+	}
+}
+


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 관련 이슈
- close #325 

</br>

## 작업 내용

- 결제 실패 처리 API 추가: POST `/api/payments/{orderId}/fail`
- Payment를 FAILED로 전이하고, DomainType.RESERVATION인 경우 ReservationService.failReservation(reservationId) 호출하여 예매를 FAILED로 변경 + 좌석(HOLD→AVAILABLE) 및 hold token 정리 수행
- 멱등성: 이미 FAILED인 결제에 대해서도 예매 실패 후처리를 재시도 가능하도록 처리

</br>

## 체크리스트

- [ ] 코딩 컨벤션 준수
- [ ] 불필요한 코드 제거
- [ ] 테스트 완료
