### PR TITLE
feat:대기열 자동 생성

### DIFF
--- a/src/main/java/com/back/b2st/domain/queue/controller/AdminQueueController.java
+++ b/src/main/java/com/back/b2st/domain/queue/controller/AdminQueueController.java
@@ -56,14 +56,14 @@ public class AdminQueueController {
 	 */
 	@Operation(
 		summary = "대기열 생성",
-		description = "새로운 대기열을 생성합니다. scheduleId와 queueType 조합은 중복될 수 없습니다."
+		description = "새로운 대기열을 생성합니다. 공연당 큐는 1개만 존재합니다 (UNIQUE 제약: performance_id)."
 	)
 	@PostMapping
 	public BaseResponse<QueueRes> createQueue(
 		@Valid @RequestBody CreateQueueReq request
 	) {
-		log.info("Admin creating queue - scheduleId: {}, queueType: {}",
-			request.scheduleId(), request.queueType());
+		log.info("Admin creating queue - performanceId: {}, queueType: {}",
+			request.performanceId(), request.queueType());
 		QueueRes response = queueManagementService.createQueue(request);
 		return BaseResponse.created(response);
 	}
@@ -71,23 +71,23 @@ public class AdminQueueController {
 	/**
 	 * 대기열 목록 조회 (필터링)
 	 * GET /api/admin/queues - 전체 목록 조회
-	 * GET /api/admin/queues?scheduleId=1 - 회차별 조회
+	 * GET /api/admin/queues?performanceId=1 - 공연별 조회
 	 * GET /api/admin/queues?queueType=BOOKING_ORDER - 타입별 조회
 	 */
 	@Operation(
 		summary = "대기열 목록 조회",
-		description = "전체 대기열 목록을 조회합니다. scheduleId 또는 queueType으로 필터링할 수 있습니다."
+		description = "전체 대기열 목록을 조회합니다. performanceId 또는 queueType으로 필터링할 수 있습니다."
 	)
 	@GetMapping
 	public BaseResponse<List<QueueRes>> getQueues(
-		@Parameter(description = "공연 회차 ID (선택)", example = "1")
-		@RequestParam(required = false) Long scheduleId,
+		@Parameter(description = "공연 ID (선택)", example = "1")
+		@RequestParam(required = false) Long performanceId,
 		@Parameter(description = "대기열 타입 (선택)", example = "BOOKING_ORDER")
 		@RequestParam(required = false) String queueType
 	) {
-		if (scheduleId != null) {
-			log.debug("Admin getting queues by schedule - scheduleId: {}", scheduleId);
-			return BaseResponse.success(queueManagementService.getQueuesBySchedule(scheduleId));
+		if (performanceId != null) {
+			log.debug("Admin getting queues by performance - performanceId: {}", performanceId);
+			return BaseResponse.success(queueManagementService.getQueuesByPerformance(performanceId));
 		}
 
 		if (queueType != null && !queueType.isBlank()) {

--- a/src/main/java/com/back/b2st/domain/queue/controller/QueueController.java
+++ b/src/main/java/com/back/b2st/domain/queue/controller/QueueController.java
@@ -9,129 +9,154 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.back.b2st.domain.queue.dto.response.QueueEntryRes;
 import com.back.b2st.domain.queue.dto.response.QueuePositionRes;
+import com.back.b2st.domain.queue.dto.response.StartBookingRes;
 import com.back.b2st.domain.queue.service.QueueService;
 import com.back.b2st.global.common.BaseResponse;
-import com.back.b2st.global.error.code.CommonErrorCode;
-import com.back.b2st.global.error.exception.BusinessException;
+import com.back.b2st.global.util.SecurityUtils;
 import com.back.b2st.security.UserPrincipal;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Positive;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * Queue 관련 API 컨트롤러
+ *
+ * 사용자의 대기열 진입, 위치 조회, 권한 소진 등을 담당합니다.
+ * 모든 엔드포인트는 로그인이 필요합니다.
+ */
 @RestController
 @RequestMapping("/api/queues")
 @RequiredArgsConstructor
 @Slf4j
 @ConditionalOnProperty(name = "queue.enabled", havingValue = "true", matchIfMissing = false)
-@Tag(name = "QueueController", description = "대기열 API (로그인 필요)")
+@Tag(name = "QueueController", description = "대기열 API (로그인 필수)")
 @SecurityRequirement(name = "BearerAuth")
 public class QueueController {
 
 	private final QueueService queueService;
 
 	/**
-	 * 대기열 입장
+	 * 예매 확정 후 권한 소진
+	 *
+	 * 사용자가 예매(좌석/결제)를 모두 완료한 후 호출합니다.
+	 * ENTERABLE 상태의 권한을 COMPLETED로 변경하여 소진 처리합니다.
+	 *
+	 * @param queueId 대기열 ID
+	 * @param principal 로그인한 사용자 정보
+	 * @return 성공 응답
 	 */
-	@Operation(summary = "대기열 입장", description = "사용자를 대기열에 등록합니다.")
-	@PostMapping("/{queueId}/enter")
-	public BaseResponse<QueueEntryRes> enterQueue(
-		@Parameter(description = "대기열 ID", example = "1")
-		@PathVariable Long queueId,
-		@AuthenticationPrincipal UserPrincipal principal
-	) {
-		// 방어 코드: Security 설정 실수/예외 케이스 대응
-		if (principal == null) {
-			throw new BusinessException(CommonErrorCode.UNAUTHORIZED);
-		}
-
-		Long userId = principal.getId();
-		log.info("User entering queue - queueId: {}, userId: {}", queueId, userId);
-
-		QueueEntryRes response = queueService.enterQueue(queueId, userId);
-		return BaseResponse.created(response);
-	}
-
-	/**
-	 * 내 대기 상태 조회 (Deprecated)
-	 */
-	@Deprecated
-	@GetMapping("/{queueId}/status")
-	public BaseResponse<QueuePositionRes> getMyStatus(
-		@PathVariable Long queueId,
-		@AuthenticationPrincipal UserPrincipal principal
-	) {
-		if (principal == null) {
-			throw new BusinessException(CommonErrorCode.UNAUTHORIZED);
-		}
-
-		Long userId = principal.getId();
-		log.debug("User checking queue status - queueId: {}, userId: {}", queueId, userId);
-
-		QueuePositionRes response = queueService.getMyPosition(queueId, userId);
-		return BaseResponse.success(response);
-	}
-
-	/**
-	 * 입장 완료 처리
-	 */
+	@Operation(
+		summary = "예매 확정 후 권한 소진",
+		description = "예매(좌석 선택, 결제)를 모두 완료한 사용자의 ENTERABLE 권한을 COMPLETED 상태로 변경하여 소진 처리합니다. " +
+			"이후 해당 사용자는 동일 공연 대기열에 다시 진입 가능합니다."
+	)
 	@PostMapping("/{queueId}/complete")
 	public BaseResponse<Void> completeEntry(
-		@PathVariable Long queueId,
+		@Parameter(description = "대기열 ID", example = "1")
+		@PathVariable @Positive Long queueId,
 		@AuthenticationPrincipal UserPrincipal principal
 	) {
-		if (principal == null) {
-			throw new BusinessException(CommonErrorCode.UNAUTHORIZED);
-		}
-
-		Long userId = principal.getId();
-		log.info("User completing entry - queueId: {}, userId: {}", queueId, userId);
-
+		Long userId = SecurityUtils.requireUserId(principal);
+		log.info("User completing booking (권한 소진) - queueId: {}, userId: {}", queueId, userId);
 		queueService.completeEntry(queueId, userId);
 		return BaseResponse.success(null);
 	}
 
 	/**
 	 * 대기열 나가기
+	 *
+	 * 사용자가 대기 중이거나 입장 가능한 상태에서 대기열을 포기할 때 호출합니다.
+	 * WAITING 또는 ENTERABLE 상태를 EXPIRED로 변경하고 Redis에서 제거합니다.
+	 *
+	 * @param queueId 대기열 ID
+	 * @param principal 로그인한 사용자 정보
+	 * @return 성공 응답
 	 */
+	@Operation(
+		summary = "대기열 나가기",
+		description = "대기 중(WAITING) 또는 입장 가능(ENTERABLE) 상태를 EXPIRED로 변경하고 Redis에서 제거합니다."
+	)
 	@DeleteMapping("/{queueId}/exit")
 	public BaseResponse<Void> exitQueue(
-		@PathVariable Long queueId,
+		@Parameter(description = "대기열 ID", example = "1")
+		@PathVariable @Positive Long queueId,
 		@AuthenticationPrincipal UserPrincipal principal
 	) {
-		if (principal == null) {
-			throw new BusinessException(CommonErrorCode.UNAUTHORIZED);
-		}
-
-		Long userId = principal.getId();
+		Long userId = SecurityUtils.requireUserId(principal);
 		log.info("User exiting queue - queueId: {}, userId: {}", queueId, userId);
-
 		queueService.exitQueue(queueId, userId);
 		return BaseResponse.success(null);
 	}
 
 	/**
 	 * 내 대기 위치 조회
+	 *
+	 * 현재 사용자의 대기열 내 위치, 상태, 앞의 인원 수를 조회합니다.
+	 * Redis 실시간 데이터를 기반으로 합니다.
+	 *
+	 * @param queueId 대기열 ID
+	 * @param principal 로그인한 사용자 정보
+	 * @return 대기 위치 정보 (상태, 랭크, 앞 인원 수)
 	 */
+	@Operation(
+		summary = "대기 위치 조회",
+		description = "현재 사용자의 대기열 상태(WAITING/ENTERABLE/EXPIRED/COMPLETED), 랭크, 앞의 인원 수를 조회합니다."
+	)
 	@GetMapping("/{queueId}/position")
 	public BaseResponse<QueuePositionRes> getMyPosition(
-		@PathVariable Long queueId,
+		@Parameter(description = "대기열 ID", example = "1")
+		@PathVariable @Positive Long queueId,
 		@AuthenticationPrincipal UserPrincipal principal
 	) {
-		if (principal == null) {
-			throw new BusinessException(CommonErrorCode.UNAUTHORIZED);
-		}
-
-		Long userId = principal.getId();
+		Long userId = SecurityUtils.requireUserId(principal);
 		log.debug("User checking queue position - queueId: {}, userId: {}", queueId, userId);
-
 		QueuePositionRes response = queueService.getMyPosition(queueId, userId);
 		return BaseResponse.success(response);
+	}
+
+	/**
+	 * 예매 시작: scheduleId로 대기열 자동 생성 및 입장 (Idempotent)
+	 *
+	 * 공연 상세 페이지에서 예매하기 버튼 클릭 시 호출합니다.
+	 *
+	 * **Idempotent 동작:**
+	 * - 이미 WAITING/ENTERABLE 상태면 409 대신 현재 상태 반환 (HTTP 201)
+	 * - 프론트는 응답의 entry.status로 화면 렌더링 가능
+	 * - 재시도/새로고침이 자주 일어나도 안전하게 처리됨
+	 *
+	 * **처리 과정:**
+	 * 1. scheduleId → performanceId 변환
+	 * 2. 공연 단위 큐 자동 생성/조회 (멱등성 보장, 레이스 컨디션 방어)
+	 * 3. 이미 WAITING/ENTERABLE 상태면 현재 상태 반환
+	 * 4. 아니면 새로운 입장 처리
+	 *
+	 * @param scheduleId 공연 회차 ID (프론트 UX용 진입 정보)
+	 * @param principal 로그인한 사용자 정보
+	 * @return 예매 시작 응답 (queueId, performanceId, scheduleId, entry 포함)
+	 */
+	@Operation(
+		summary = "예매 시작 (Idempotent)",
+		description = "공연 회차 ID로 대기열을 자동 생성하고 입장합니다. " +
+			"대기열이 없으면 자동으로 생성됩니다. " +
+			"공연 단위로 큐가 관리됩니다. " +
+			"이미 대기 중이거나 입장 가능한 상태면 현재 상태를 반환합니다 (409 대신 201)."
+	)
+	@PostMapping("/start-booking/{scheduleId}")
+	public BaseResponse<StartBookingRes> startBooking(
+		@Parameter(description = "공연 회차 ID (프론트 UX용 진입 정보)", example = "1")
+		@PathVariable @Positive Long scheduleId,
+		@AuthenticationPrincipal UserPrincipal principal
+	) {
+		Long userId = SecurityUtils.requireUserId(principal);
+		log.info("User starting booking - scheduleId: {}, userId: {}", scheduleId, userId);
+		StartBookingRes response = queueService.startBooking(scheduleId, userId);
+		return BaseResponse.created(response);
 	}
 }

--- a/src/main/java/com/back/b2st/domain/queue/dto/QueueDefaultPolicy.java
+++ b/src/main/java/com/back/b2st/domain/queue/dto/QueueDefaultPolicy.java
@@ -1,0 +1,24 @@
+package com.back.b2st.domain.queue.dto;
+
+import com.back.b2st.domain.queue.entity.QueueType;
+
+/**
+ * 대기열 자동 생성 시 사용하는 기본 정책
+ */
+public record QueueDefaultPolicy(
+	QueueType queueType,
+	Integer maxActiveUsers,
+	Integer entryTtlMinutes
+) {
+	/**
+	 * 예매용 기본 정책
+	 */
+	public static QueueDefaultPolicy defaultBooking() {
+		return new QueueDefaultPolicy(
+			QueueType.BOOKING_ORDER,
+			200,
+			10
+		);
+	}
+}
+

--- a/src/main/java/com/back/b2st/domain/queue/dto/request/CreateQueueReq.java
+++ b/src/main/java/com/back/b2st/domain/queue/dto/request/CreateQueueReq.java
@@ -8,8 +8,8 @@ import jakarta.validation.constraints.NotNull;
  * 대기열 생성 요청 DTO
  */
 public record CreateQueueReq(
-	@NotNull(message = "회차 ID는 필수입니다.")
-	Long scheduleId,
+	@NotNull(message = "공연 ID는 필수입니다.")
+	Long performanceId,
 
 	@NotBlank(message = "대기열 타입은 필수입니다.")
 	String queueType,

--- a/src/main/java/com/back/b2st/domain/queue/dto/response/QueueEntryRes.java
+++ b/src/main/java/com/back/b2st/domain/queue/dto/response/QueueEntryRes.java
@@ -9,6 +9,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record QueueEntryRes(
 	Long queueId,
+	Long performanceId,
+	Long scheduleId,         // 프론트 UX용 진입 정보
 	Long userId,
 	String status,            // WAITING(Redis), ENTERABLE, EXPIRED, COMPLETED
 	Integer aheadCount,      // 내 앞에 대기 중인 사람 수
@@ -18,9 +20,11 @@ public record QueueEntryRes(
 	/**
 	 * WAITING 상태 응답 (Redis에만 존재)
 	 */
-	public static QueueEntryRes waiting(Long queueId, Long userId, Integer aheadCount, Integer myRank) {
+	public static QueueEntryRes waiting(Long queueId, Long performanceId, Long scheduleId, Long userId, Integer aheadCount, Integer myRank) {
 		return new QueueEntryRes(
 			queueId,
+			performanceId,
+			scheduleId,
 			userId,
 			"WAITING",
 			aheadCount,
@@ -31,9 +35,11 @@ public record QueueEntryRes(
 	/**
 	 * QueueEntry → Response 변환 (DB 저장된 상태)
 	 */
-	public static QueueEntryRes of(QueueEntry entry, Integer aheadCount, Integer myRank) {
+	public static QueueEntryRes of(QueueEntry entry, Long performanceId, Long scheduleId, Integer aheadCount, Integer myRank) {
 		return new QueueEntryRes(
 			entry.getQueueId(),
+			performanceId,
+			scheduleId,
 			entry.getUserId(),
 			entry.getStatus().name(),
 			aheadCount,
@@ -44,9 +50,11 @@ public record QueueEntryRes(
 	/**
 	 * 간단한 응답 (순번 정보 없음)
 	 */
-	public static QueueEntryRes simple(QueueEntry entry) {
+	public static QueueEntryRes simple(QueueEntry entry, Long performanceId, Long scheduleId) {
 		return new QueueEntryRes(
 			entry.getQueueId(),
+			performanceId,
+			scheduleId,
 			entry.getUserId(),
 			entry.getStatus().name(),
 			null,

--- a/src/main/java/com/back/b2st/domain/queue/dto/response/QueueRes.java
+++ b/src/main/java/com/back/b2st/domain/queue/dto/response/QueueRes.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record QueueRes(
 	Long queueId,
-	Long scheduleId,
+	Long performanceId,
 	String queueType,
 	Integer maxActiveUsers,
 	Integer entryTtlMinutes,
@@ -23,7 +23,7 @@ public record QueueRes(
 	public static QueueRes from(Queue queue) {
 		return new QueueRes(
 			queue.getId(),
-			queue.getScheduleId(),
+			queue.getPerformanceId(),
 			queue.getQueueType().name(),
 			queue.getMaxActiveUsers(),
 			queue.getEntryTtlMinutes(),
@@ -38,7 +38,7 @@ public record QueueRes(
 	public static QueueRes of(Queue queue, Integer currentWaiting, Integer currentEnterable) {
 		return new QueueRes(
 			queue.getId(),
-			queue.getScheduleId(),
+			queue.getPerformanceId(),
 			queue.getQueueType().name(),
 			queue.getMaxActiveUsers(),
 			queue.getEntryTtlMinutes(),

--- a/src/main/java/com/back/b2st/domain/queue/dto/response/StartBookingRes.java
+++ b/src/main/java/com/back/b2st/domain/queue/dto/response/StartBookingRes.java
@@ -1,0 +1,19 @@
+package com.back.b2st.domain.queue.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * 예매 시작 응답 DTO
+ *
+ * 프론트 UX가 "상세에서 회차 선택 → 대기열 진입"이므로 scheduleId를 입력으로 받고,
+ * 서버 정책은 공연 단위 queueId 1개이므로 응답에 queueId, performanceId, scheduleId를 포함
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record StartBookingRes(
+	Long queueId,        // 공연 단위 큐 ID
+	Long performanceId,  // 권한 체크/좌석 API의 기준
+	Long scheduleId,     // 첫 진입 회차로 프론트가 세팅
+	QueueEntryRes entry  // 대기열 입장 상세 정보
+) {
+}
+

--- a/src/main/java/com/back/b2st/domain/queue/entity/Queue.java
+++ b/src/main/java/com/back/b2st/domain/queue/entity/Queue.java
@@ -27,17 +27,18 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(
-		name = "queues",
-		uniqueConstraints = {@UniqueConstraint(
-						name = "uk_queue_schedule_type",
-						columnNames = {"schedule_id", "queue_type"}
-				)
-		}
+	name = "queues",
+	uniqueConstraints = {
+		@UniqueConstraint(
+			name = "uk_queue_performance",
+			columnNames = {"performance_id"}
+		)
+	}
 )
 @SequenceGenerator(
-		name = "queue_id_gen",
-		sequenceName = "queue_seq",
-		allocationSize = 50
+	name = "queue_id_gen",
+	sequenceName = "queue_seq",
+	allocationSize = 50
 )
 @DynamicUpdate
 public class Queue extends BaseEntity {
@@ -48,9 +49,9 @@ public class Queue extends BaseEntity {
 	@Schema(description = "대기열 ID", example = "1")
 	private Long id;
 
-	@Column(name = "schedule_id", nullable = false)
-	@Schema(description = "공연 회차 ID", example = "1")
-	private Long scheduleId;
+	@Column(name = "performance_id", nullable = false)
+	@Schema(description = "공연 ID", example = "1")
+	private Long performanceId;
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "queue_type", nullable = false, length = 20)
@@ -67,12 +68,12 @@ public class Queue extends BaseEntity {
 
 	@Builder
 	public Queue(
-			Long scheduleId,
-			QueueType queueType,
-			Integer maxActiveUsers,
-			Integer entryTtlMinutes
+		Long performanceId,
+		QueueType queueType,
+		Integer maxActiveUsers,
+		Integer entryTtlMinutes
 	) {
-		this.scheduleId = scheduleId;
+		this.performanceId = performanceId;
 		this.queueType = queueType;
 		this.maxActiveUsers = maxActiveUsers;
 		this.entryTtlMinutes = entryTtlMinutes;

--- a/src/main/java/com/back/b2st/domain/queue/repository/QueueRepository.java
+++ b/src/main/java/com/back/b2st/domain/queue/repository/QueueRepository.java
@@ -14,14 +14,20 @@ import com.back.b2st.domain.queue.entity.QueueType;
 public interface QueueRepository extends JpaRepository<Queue, Long> {
 
 	/**
-	 * 회차 ID와 대기열 타입으로 대기열 조회
+	 * 공연 ID로 대기열 조회
+	 * UNIQUE 제약: (performance_id)
 	 */
-	Optional<Queue> findByScheduleIdAndQueueType(Long scheduleId, QueueType queueType);
+	Optional<Queue> findByPerformanceId(Long performanceId);
 
 	/**
-	 * 회차 ID로 모든 대기열 조회
+	 * 대기열 존재 여부 확인 (공연 기준)
 	 */
-	List<Queue> findByScheduleId(Long scheduleId);
+	boolean existsByPerformanceId(Long performanceId);
+
+	/**
+	 * 여러 공연의 대기열 목록 일괄 조회
+	 */
+	List<Queue> findByPerformanceIdIn(Collection<Long> performanceIds);
 
 	/**
 	 * 대기열 타입으로 조회
@@ -29,23 +35,9 @@ public interface QueueRepository extends JpaRepository<Queue, Long> {
 	List<Queue> findByQueueType(QueueType queueType);
 
 	/**
-	 * 여러 회차의 대기열 목록 일괄 조회
-	 */
-	List<Queue> findByScheduleIdIn(Collection<Long> scheduleIds);
-
-	/**
-	 * 대기열 존재 여부 확인
-	 */
-	boolean existsByScheduleIdAndQueueType(Long scheduleId, QueueType queueType);
-
-	/**
-	 * 특정 회차의 대기열 개수
-	 */
-	long countByScheduleId(Long scheduleId);
-
-	/**
 	 * 대용량 대기열 조회 (동시 입장 허용 수가 특정 값 이상)
 	 */
 	@Query("SELECT q FROM Queue q WHERE q.maxActiveUsers >= :minActiveUsers")
 	List<Queue> findLargeCapacityQueues(@Param("minActiveUsers") Integer minActiveUsers);
 }
+

--- a/src/main/java/com/back/b2st/domain/queue/service/QueueAccessService.java
+++ b/src/main/java/com/back/b2st/domain/queue/service/QueueAccessService.java
@@ -1,0 +1,76 @@
+package com.back.b2st.domain.queue.service;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import com.back.b2st.domain.queue.entity.Queue;
+import com.back.b2st.domain.queue.error.QueueErrorCode;
+import com.back.b2st.domain.queue.repository.QueueRepository;
+import com.back.b2st.domain.queue.repository.QueueRedisRepository;
+import com.back.b2st.global.error.exception.BusinessException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 대기열 접근 제어 서비스
+ *
+ * 다른 도메인(예매/좌석)에서 사용할 수 있는 명확한 인터페이스 제공
+ * ENTERABLE 권한은 공연(performanceId) 기준으로만 발급
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@ConditionalOnProperty(name = "queue.enabled", havingValue = "true", matchIfMissing = false)
+public class QueueAccessService {
+
+	private final QueueRepository queueRepository;
+	private final QueueRedisRepository queueRedisRepository;
+
+	/**
+	 * 사용자가 해당 공연의 대기열을 통과했는지 확인
+	 *
+	 * @param performanceId 공연 ID
+	 * @param userId 사용자 ID
+	 * @return ENTERABLE 상태면 true, 아니면 false
+	 */
+	public boolean isEnterable(Long performanceId, Long userId) {
+		// 1. 공연의 큐가 존재하는지 확인
+		Queue queue = queueRepository.findByPerformanceId(performanceId)
+			.orElse(null);
+
+		if (queue == null) {
+			log.debug("Queue not found for performanceId: {}", performanceId);
+			return false;
+		}
+
+		// 2. Redis에서 ENTERABLE 상태 확인 (SoT)
+		try {
+			boolean enterable = queueRedisRepository.isInEnterable(queue.getId(), userId);
+			log.debug("isEnterable check - performanceId: {}, userId: {}, queueId: {}, result: {}",
+				performanceId, userId, queue.getId(), enterable);
+			return enterable;
+		} catch (Exception e) {
+			log.warn("Redis operation failed in isEnterable - performanceId: {}, userId: {}", performanceId, userId, e);
+			return false;
+		}
+	}
+
+	/**
+	 * 사용자가 해당 공연의 대기열을 통과했는지 확인 (권장)
+	 *
+	 * ENTERABLE 상태가 아니면 BusinessException throw
+	 *
+	 * @param performanceId 공연 ID
+	 * @param userId 사용자 ID
+	 * @throws BusinessException ENTERABLE 상태가 아닐 때 (QUEUE_ENTRY_EXPIRED)
+	 */
+	public void assertEnterable(Long performanceId, Long userId) {
+		if (!isEnterable(performanceId, userId)) {
+			log.warn("User not enterable - performanceId: {}, userId: {}", performanceId, userId);
+			throw new BusinessException(QueueErrorCode.QUEUE_ENTRY_EXPIRED);
+		}
+		log.debug("User enterable verified - performanceId: {}, userId: {}", performanceId, userId);
+	}
+}
+

--- a/src/main/java/com/back/b2st/domain/queue/service/QueueManagementService.java
+++ b/src/main/java/com/back/b2st/domain/queue/service/QueueManagementService.java
@@ -1,13 +1,16 @@
 package com.back.b2st.domain.queue.service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.back.b2st.domain.queue.dto.QueueDefaultPolicy;
 import com.back.b2st.domain.queue.dto.request.CreateQueueReq;
 import com.back.b2st.domain.queue.dto.request.UpdateQueueReq;
 import com.back.b2st.domain.queue.dto.response.QueueRes;
@@ -39,10 +42,10 @@ public class QueueManagementService {
 	@Transactional
 	public QueueRes createQueue(CreateQueueReq request) {
 		QueueType queueType = validateQueueType(request.queueType());
-		validateNotDuplicated(request.scheduleId(), queueType);
+		validateNotDuplicated(request.performanceId());
 
 		Queue queue = Queue.builder()
-			.scheduleId(request.scheduleId())
+			.performanceId(request.performanceId())
 			.queueType(queueType)
 			.maxActiveUsers(request.maxActiveUsers())
 			.entryTtlMinutes(request.entryTtlMinutes())
@@ -50,13 +53,52 @@ public class QueueManagementService {
 
 		try {
 			queue = queueRepository.save(queue);
-			log.info("Queue created - queueId: {}, scheduleId: {}, type: {}",
-				queue.getId(), queue.getScheduleId(), queue.getQueueType());
+			log.info("Queue created - queueId: {}, performanceId: {}, type: {}",
+				queue.getId(), queue.getPerformanceId(), queue.getQueueType());
 			return QueueRes.from(queue);
 		} catch (DataAccessException e) {
 			log.error("Failed to create queue", e);
 			throw new BusinessException(QueueErrorCode.QUEUE_INTERNAL_ERROR);
 		}
+	}
+
+	/**
+	 * 공연 ID로 대기열을 조회하거나 생성 (멱등성 보장)
+	 *
+	 * 레이스 컨디션 방어: 동시에 여러 요청이 와도 하나의 큐만 생성됨
+	 *
+	 * @param performanceId 공연 ID
+	 * @param policy 기본 정책 (없을 때 생성 시 사용)
+	 * @return 대기열 엔티티
+	 */
+	@Transactional
+	public Queue getOrCreateByPerformanceId(Long performanceId, QueueDefaultPolicy policy) {
+		// 1. 이미 존재하는지 확인
+		return queueRepository.findByPerformanceId(performanceId)
+			.orElseGet(() -> {
+				log.info("Queue not found for performanceId: {}, creating new queue", performanceId);
+				// 2. 생성 시도
+				try {
+					Queue newQueue = Queue.builder()
+						.performanceId(performanceId)
+						.queueType(policy.queueType())
+						.maxActiveUsers(policy.maxActiveUsers())
+						.entryTtlMinutes(policy.entryTtlMinutes())
+						.build();
+
+					Queue saved = queueRepository.save(newQueue);
+					log.info("Queue created - queueId: {}, performanceId: {}", saved.getId(), performanceId);
+					return saved;
+				} catch (DataIntegrityViolationException e) {
+					// 3. 레이스 컨디션: 다른 스레드가 이미 생성함
+					log.debug("Race condition detected, queue already exists for performanceId: {}", performanceId);
+					return queueRepository.findByPerformanceId(performanceId)
+						.orElseThrow(() -> {
+							log.error("Failed to find queue after race condition - performanceId: {}", performanceId);
+							return new BusinessException(QueueErrorCode.QUEUE_INTERNAL_ERROR);
+						});
+				}
+			});
 	}
 
 	public QueueRes getQueue(Long queueId) {
@@ -71,18 +113,39 @@ public class QueueManagementService {
 		return QueueRes.of(queue, currentWaiting, currentEnterable);
 	}
 
-	public List<QueueRes> getQueuesBySchedule(Long scheduleId) {
-		List<Queue> queues = queueRepository.findByScheduleId(scheduleId);
+	/**
+	 * 공연 ID로 대기열 조회
+	 *
+	 * 공연당 큐는 1개만 존재하므로 (UNIQUE 제약), List로 반환하되 최대 1개만 포함
+	 *
+	 * @param performanceId 공연 ID
+	 * @return 해당 공연의 대기열 목록 (최대 1개, Redis 실시간 카운트 포함)
+	 */
+	public List<QueueRes> getQueuesByPerformance(Long performanceId) {
+		log.debug("Getting queues by performanceId: {}", performanceId);
+		Optional<Queue> queueOpt = queueRepository.findByPerformanceId(performanceId);
 
-		return queues.stream()
-			.map(queue -> {
-				int currentWaiting = getRedisCountWithFallback(() ->
-					queueRedisRepository.getTotalWaitingCount(queue.getId()));
-				int currentEnterable = getRedisCountWithFallback(() ->
-					queueRedisRepository.getTotalEnterableCount(queue.getId()));
-				return QueueRes.of(queue, currentWaiting, currentEnterable);
-			})
-			.collect(Collectors.toList());
+		if (queueOpt.isEmpty()) {
+			return List.of();
+		}
+
+		Queue queue = queueOpt.get();
+		int currentWaiting = getRedisCountWithFallback(() ->
+			queueRedisRepository.getTotalWaitingCount(queue.getId()));
+		int currentEnterable = getRedisCountWithFallback(() ->
+			queueRedisRepository.getTotalEnterableCount(queue.getId()));
+
+		return List.of(QueueRes.of(queue, currentWaiting, currentEnterable));
+	}
+
+	/**
+	 * @deprecated scheduleId 기반 조회는 더 이상 사용하지 않음. performanceId 기반 조회를 사용하세요.
+	 */
+	@Deprecated
+	public List<QueueRes> getQueuesBySchedule(Long scheduleId) {
+		// 더 이상 scheduleId로 조회할 수 없으므로 빈 리스트 반환
+		log.warn("getQueuesBySchedule is deprecated. Use performanceId-based query instead. scheduleId: {}", scheduleId);
+		return List.of();
 	}
 
 	public List<QueueRes> getQueuesByType(String queueType) {
@@ -147,16 +210,24 @@ public class QueueManagementService {
 
 		try {
 			queueRepository.delete(queue);
-			log.info("Queue deleted - queueId: {}, scheduleId: {}", queueId, queue.getScheduleId());
+			log.info("Queue deleted - queueId: {}, performanceId: {}", queueId, queue.getPerformanceId());
 		} catch (DataAccessException e) {
 			log.error("Failed to delete queue - queueId: {}", queueId, e);
 			throw new BusinessException(QueueErrorCode.QUEUE_INTERNAL_ERROR);
 		}
 	}
 
+	public boolean existsQueue(Long performanceId) {
+		return queueRepository.existsByPerformanceId(performanceId);
+	}
+
+	/**
+	 * @deprecated scheduleId 기반 조회는 더 이상 사용하지 않음. performanceId 기반 조회를 사용하세요.
+	 */
+	@Deprecated
 	public boolean existsQueue(Long scheduleId, String queueType) {
-		QueueType type = validateQueueType(queueType);
-		return queueRepository.existsByScheduleIdAndQueueType(scheduleId, type);
+		log.warn("existsQueue(scheduleId, queueType) is deprecated. Use existsQueue(performanceId) instead.");
+		return false;
 	}
 
 	private Queue validateQueue(Long queueId) {
@@ -172,8 +243,8 @@ public class QueueManagementService {
 		}
 	}
 
-	private void validateNotDuplicated(Long scheduleId, QueueType queueType) {
-		if (queueRepository.existsByScheduleIdAndQueueType(scheduleId, queueType)) {
+	private void validateNotDuplicated(Long performanceId) {
+		if (queueRepository.existsByPerformanceId(performanceId)) {
 			throw new BusinessException(QueueErrorCode.ALREADY_IN_QUEUE);
 		}
 	}

--- a/src/main/java/com/back/b2st/domain/queue/service/QueueService.java
+++ b/src/main/java/com/back/b2st/domain/queue/service/QueueService.java
@@ -1,23 +1,12 @@
 package com.back.b2st.domain.queue.service;
 
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.function.Supplier;
-
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.dao.DataAccessException;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.back.b2st.domain.queue.dto.MoveResult;
+import com.back.b2st.domain.queue.dto.QueueDefaultPolicy;
 import com.back.b2st.domain.queue.dto.QueueEntryStatusCount;
 import com.back.b2st.domain.queue.dto.response.QueueEntryRes;
 import com.back.b2st.domain.queue.dto.response.QueuePositionRes;
 import com.back.b2st.domain.queue.dto.response.QueueStatisticsRes;
+import com.back.b2st.domain.queue.dto.response.StartBookingRes;
 import com.back.b2st.domain.queue.entity.Queue;
 import com.back.b2st.domain.queue.entity.QueueEntry;
 import com.back.b2st.domain.queue.entity.QueueEntryStatus;
@@ -26,9 +15,19 @@ import com.back.b2st.domain.queue.repository.QueueEntryRepository;
 import com.back.b2st.domain.queue.repository.QueueRedisRepository;
 import com.back.b2st.domain.queue.repository.QueueRepository;
 import com.back.b2st.global.error.exception.BusinessException;
-
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.dao.DataAccessException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -42,6 +41,8 @@ public class QueueService {
 	private final QueueRepository queueRepository;
 	private final QueueEntryRepository queueEntryRepository;
 	private final QueueRedisRepository queueRedisRepository;
+	private final QueueManagementService queueManagementService;
+	private final ScheduleResolver scheduleResolver;
 
 	private <T> T runRedis(String op, Long queueId, Long userId, Supplier<T> supplier) {
 		try {
@@ -65,8 +66,17 @@ public class QueueService {
 		return LocalDateTime.now(KST);
 	}
 
+	/**
+	 * 대기열 입장 (내부 메서드)
+	 *
+	 * @param queueId 대기열 ID
+	 * @param performanceId 공연 ID
+	 * @param scheduleId 회차 ID (프론트 UX용)
+	 * @param userId 사용자 ID
+	 * @return 대기열 입장 결과
+	 */
 	@Transactional
-	public QueueEntryRes enterQueue(Long queueId, Long userId) {
+	public QueueEntryRes enterQueue(Long queueId, Long performanceId, Long scheduleId, Long userId) {
 		validateQueue(queueId);
 		validateNotDuplicated(queueId, userId);
 
@@ -93,7 +103,103 @@ public class QueueService {
 		int aheadCount = rank0.intValue();
 		int myRank = rank0.intValue() + 1;
 
-		return QueueEntryRes.waiting(queueId, userId, aheadCount, myRank);
+		return QueueEntryRes.waiting(queueId, performanceId, scheduleId, userId, aheadCount, myRank);
+	}
+
+	/**
+	 * 대기열 입장 (기존 호환성 유지용 - deprecated)
+	 *
+	 * @deprecated performanceId, scheduleId를 포함하는 enterQueue(Long, Long, Long, Long)를 사용하세요.
+	 */
+	@Deprecated
+	@Transactional
+	public QueueEntryRes enterQueue(Long queueId, Long userId) {
+		Queue queue = validateQueue(queueId);
+		// 성능상 이슈가 있을 수 있으나 호환성을 위해 유지
+		log.warn("enterQueue(queueId, userId) is deprecated. Use enterQueue(queueId, performanceId, scheduleId, userId) instead.");
+		return enterQueue(queueId, queue.getPerformanceId(), null, userId);
+	}
+
+	/**
+	 * 예매 시작: scheduleId로 대기열 자동 생성 및 입장 (Idempotent)
+	 *
+	 * 공연 단위 큐를 보장: scheduleId → performanceId 변환 후 getOrCreate
+	 *
+	 * Idempotent 동작:
+	 * - 이미 WAITING/ENTERABLE 상태면 409 대신 현재 상태 반환
+	 * - 프론트는 응답의 status로 화면 렌더링 가능
+	 * - 재시도/새로고침이 자주 일어나도 안전하게 처리
+	 *
+	 * @param scheduleId 공연 회차 ID (프론트 UX용 진입 정보)
+	 * @param userId 사용자 ID
+	 * @return 예매 시작 응답 (queueId, performanceId, scheduleId, entry 포함)
+	 */
+	@Transactional
+	public StartBookingRes startBooking(Long scheduleId, Long userId) {
+		// 1. scheduleId → performanceId 변환
+		Long performanceId = scheduleResolver.resolvePerformanceId(scheduleId);
+		log.debug("Resolved scheduleId: {} -> performanceId: {}", scheduleId, performanceId);
+
+		// 2. 공연 단위 큐 조회 또는 생성 (멱등성 보장)
+		Queue queue = queueManagementService.getOrCreateByPerformanceId(
+			performanceId,
+			QueueDefaultPolicy.defaultBooking()
+		);
+
+		Long queueId = queue.getId();
+		log.info("Queue resolved/created - queueId: {}, performanceId: {}, scheduleId: {}",
+			queueId, performanceId, scheduleId);
+
+		// 3. 이미 WAITING 또는 ENTERABLE 상태인지 확인 (Idempotent)
+		boolean inWaiting = runRedis("isInWaitingQueue", queueId, userId,
+			() -> queueRedisRepository.isInWaitingQueue(queueId, userId)
+		);
+
+		boolean inEnterable = runRedis("isInEnterable", queueId, userId,
+			() -> queueRedisRepository.isInEnterable(queueId, userId)
+		);
+
+		// 4. 이미 대기 중이거나 입장 가능한 상태면 현재 상태 반환
+		if (inWaiting || inEnterable) {
+			log.debug("User already in queue (idempotent) - queueId: {}, userId: {}, inWaiting: {}, inEnterable: {}",
+				queueId, userId, inWaiting, inEnterable);
+
+			QueuePositionRes position = getMyPosition(queueId, userId);
+			QueueEntryRes entry = convertPositionToEntry(position, performanceId, scheduleId);
+
+			return new StartBookingRes(
+				queueId,
+				performanceId,
+				scheduleId,
+				entry
+			);
+		}
+
+		// 5. 새로운 입장 처리
+		QueueEntryRes entry = enterQueue(queueId, performanceId, scheduleId, userId);
+
+		// 6. StartBookingRes 반환
+		return new StartBookingRes(
+			queueId,
+			performanceId,
+			scheduleId,
+			entry
+		);
+	}
+
+	/**
+	 * QueuePositionRes를 QueueEntryRes로 변환
+	 */
+	private QueueEntryRes convertPositionToEntry(QueuePositionRes position, Long performanceId, Long scheduleId) {
+		return new QueueEntryRes(
+			position.queueId(),
+			performanceId,
+			scheduleId,
+			position.userId(),
+			position.status(),
+			position.aheadCount(),
+			position.myRank()
+		);
 	}
 
 	public QueuePositionRes getMyStatus(Long queueId, Long userId) {
@@ -300,9 +406,11 @@ public class QueueService {
 			throw new BusinessException(QueueErrorCode.ALREADY_IN_QUEUE);
 		}
 
-		Optional<QueueEntry> existingEntry = queueEntryRepository.findByQueueIdAndUserId(queueId, userId);
-		if (existingEntry.isPresent() && existingEntry.get().getStatus() == QueueEntryStatus.COMPLETED) {
-			throw new BusinessException(QueueErrorCode.ALREADY_IN_QUEUE);
-		}
+		//EXIT/COMPLETE 이후엔 "처음부터 재진입" 허용
+		//DB의 COMPLETED/EXPIRED 기록은 히스토리로만 남기고 재진입을 막지 않는다.
+		//Optional<QueueEntry> existingEntry = queueEntryRepository.findByQueueIdAndUserId(queueId, userId);
+		//if (existingEntry.isPresent() && existingEntry.get().getStatus() == QueueEntryStatus.COMPLETED) {
+		//	throw new BusinessException(QueueErrorCode.ALREADY_IN_QUEUE);
+		//}
 	}
 }

--- a/src/main/java/com/back/b2st/domain/queue/service/ScheduleResolver.java
+++ b/src/main/java/com/back/b2st/domain/queue/service/ScheduleResolver.java
@@ -1,0 +1,46 @@
+package com.back.b2st.domain.queue.service;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import com.back.b2st.domain.performanceschedule.entity.PerformanceSchedule;
+import com.back.b2st.domain.performanceschedule.repository.PerformanceScheduleRepository;
+import com.back.b2st.global.error.code.CommonErrorCode;
+import com.back.b2st.global.error.exception.BusinessException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * ScheduleId를 PerformanceId로 변환하는 Resolver
+ *
+ * 대기열 도메인에서 scheduleId(회차)를 performanceId(공연)로 변환하는 책임 담당
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@ConditionalOnProperty(name = "queue.enabled", havingValue = "true", matchIfMissing = false)
+public class ScheduleResolver {
+
+	private final PerformanceScheduleRepository performanceScheduleRepository;
+
+	/**
+	 * scheduleId를 performanceId로 변환
+	 *
+	 * @param scheduleId 공연 회차 ID
+	 * @return 공연 ID
+	 * @throws BusinessException scheduleId가 존재하지 않을 때
+	 */
+	public Long resolvePerformanceId(Long scheduleId) {
+		PerformanceSchedule schedule = performanceScheduleRepository.findById(scheduleId)
+			.orElseThrow(() -> {
+				log.warn("Schedule not found - scheduleId: {}", scheduleId);
+				return new BusinessException(CommonErrorCode.NOT_FOUND);
+			});
+
+		Long performanceId = schedule.getPerformance().getPerformanceId();
+		log.debug("Resolved scheduleId: {} -> performanceId: {}", scheduleId, performanceId);
+		return performanceId;
+	}
+}
+

--- a/src/main/java/com/back/b2st/global/util/SecurityUtils.java
+++ b/src/main/java/com/back/b2st/global/util/SecurityUtils.java
@@ -1,0 +1,17 @@
+package com.back.b2st.global.util;
+
+import com.back.b2st.global.error.code.CommonErrorCode;
+import com.back.b2st.global.error.exception.BusinessException;
+import com.back.b2st.security.UserPrincipal;
+
+public final class SecurityUtils {
+
+	private SecurityUtils() {}
+
+	public static Long requireUserId(UserPrincipal principal) {
+		if (principal == null) {
+			throw new BusinessException(CommonErrorCode.UNAUTHORIZED);
+		}
+		return principal.getId();
+	}
+}


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 관련 이슈
- close #446 

</br>

## 작업 내용
- 대기열 자동 생성
1. 예매 시작 플로우
공연 상세 페이지 → "예매하기" 버튼 클릭
  ↓
POST /api/queues/start-booking/{scheduleId}
  ↓
response.entry.status 확인:
  - WAITING: 대기 화면 (aheadCount, myRank 표시)
  - ENTERABLE: 좌석 선택 화면으로 이동
2. 대기열 자동 생성 방식

사용자가 "예매하기" 클릭 시 서버에서 자동으로 큐 생성
프론트에서 별도로 큐 생성 API 호출 불필요
scheduleId만 전달하면 됨
공연 단위로 큐가 관리(여러 회차가 하나의 큐 공유)

</br>

## 체크리스트
- [ ] 코딩 컨벤션 준수
- [ ] 불필요한 코드 제거
- [ ] 테스트 완료
