### PR TITLE
feat: 신청예매(사전신청) 운영 반영

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -335,6 +335,8 @@ services:
       - "8080:8080"
     environment:
       - SPRING_PROFILES_ACTIVE=prod
+      - JAVA_TOOL_OPTIONS=-Duser.timezone=Asia/Seoul
+      - APP_FRONTEND_MY_PAGE_URL=${APP_FRONTEND_MY_PAGE_URL:-https://doncrytt.vercel.app/my-page}
       - AWS_S3_BUCKET=${AWS_S3_BUCKET}
       - AWS_REGION=${AWS_REGION:-ap-northeast-2}
       - POSTGRES_USER=${POSTGRES_USER}

--- a/src/main/java/com/back/b2st/domain/email/service/EmailSender.java
+++ b/src/main/java/com/back/b2st/domain/email/service/EmailSender.java
@@ -3,6 +3,7 @@ package com.back.b2st.domain.email.service;
 import static com.back.b2st.global.util.MaskingUtil.*;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -58,6 +59,17 @@ public class EmailSender {
 			Map.of(
 				"message", message
 			));
+	}
+
+	@Async("emailExecutor")
+	public void sendNotificationEmail(String to, String subject, String message, String actionText, String actionUrl) {
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("message", message);
+		if (actionUrl != null && !actionUrl.isBlank()) {
+			variables.put("actionUrl", actionUrl);
+			variables.put("actionText", (actionText == null || actionText.isBlank()) ? "바로가기" : actionText);
+		}
+		sendTemplateEmail(to, subject, "email/notification", variables);
 	}
 
 	@Async("emailExecutor")

--- a/src/main/java/com/back/b2st/domain/prereservation/booking/service/PrereservationHoldService.java
+++ b/src/main/java/com/back/b2st/domain/prereservation/booking/service/PrereservationHoldService.java
@@ -43,7 +43,7 @@ public class PrereservationHoldService {
 			.orElseThrow(() -> new BusinessException(PrereservationErrorCode.SCHEDULE_NOT_FOUND));
 
 		if (schedule.getBookingType() != BookingType.PRERESERVE) {
-			return;
+			throw new BusinessException(PrereservationErrorCode.BOOKING_TYPE_NOT_SUPPORTED);
 		}
 
 		LocalDateTime bookingOpenAt = schedule.getBookingOpenAt();

--- a/src/main/java/com/back/b2st/domain/prereservation/entry/error/PrereservationErrorCode.java
+++ b/src/main/java/com/back/b2st/domain/prereservation/entry/error/PrereservationErrorCode.java
@@ -24,7 +24,7 @@ public enum PrereservationErrorCode implements ErrorCode {
 	APPLICATION_NOT_OPEN(HttpStatus.FORBIDDEN, "PR010", "신청 예매 신청 기간이 아닙니다."),
 	BOOKING_SLOT_NOT_OPEN(HttpStatus.FORBIDDEN, "PR011", "현재 시간에는 해당 구역 예매가 불가능합니다."),
 	BOOKING_TIME_NOT_CONFIGURED(HttpStatus.CONFLICT, "PR012", "예매 시간이 설정되지 않았습니다."),
-	TIME_TABLE_NOT_CONFIGURED(HttpStatus.CONFLICT, "PR013", "구역별 예매 시간대가 설정되지 않았습니다."),
+	TIME_TABLE_NOT_CONFIGURED(HttpStatus.CONFLICT, "PR013", "구역별 예매 시간대가 올바르게 설정되지 않았습니다."),
 	RESERVATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "PR014", "이미 예매가 진행 중이거나 완료된 좌석입니다."),
 	RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "PR015", "예매 정보를 찾을 수 없습니다.");
 

--- a/src/main/java/com/back/b2st/domain/prereservation/entry/service/PrereservationApplyService.java
+++ b/src/main/java/com/back/b2st/domain/prereservation/entry/service/PrereservationApplyService.java
@@ -43,6 +43,9 @@ public class PrereservationApplyService {
 	@Value("${prereservation.application.strict:true}")
 	private boolean applicationStrict = true;
 
+	@Value("${app.frontend.my-page-url:https://doncrytt.vercel.app/my-page}")
+	private String myPageUrl = "https://doncrytt.vercel.app/my-page";
+
 	@Transactional
 	public void apply(Long scheduleId, Long memberId, String email, Long sectionId) {
 		PerformanceSchedule schedule = getScheduleOrThrow(scheduleId);
@@ -167,6 +170,12 @@ public class PrereservationApplyService {
 			endAt.format(EMAIL_TIME_FORMATTER)
 		);
 
-		emailSender.sendNotificationEmail(email, "[TT] 신청 예매 사전 신청 완료", message);
+		emailSender.sendNotificationEmail(
+			email,
+			"[TT] 신청 예매 사전 신청 완료",
+			message,
+			"예매 바로가기",
+			myPageUrl
+		);
 	}
 }

--- a/src/main/java/com/back/b2st/domain/prereservation/policy/controller/PrereservationTimeTableController.java
+++ b/src/main/java/com/back/b2st/domain/prereservation/policy/controller/PrereservationTimeTableController.java
@@ -60,4 +60,3 @@ public class PrereservationTimeTableController {
 		return BaseResponse.created(null);
 	}
 }
-

--- a/src/main/java/com/back/b2st/domain/prereservation/policy/service/PrereservationTimeTableService.java
+++ b/src/main/java/com/back/b2st/domain/prereservation/policy/service/PrereservationTimeTableService.java
@@ -48,6 +48,7 @@ public class PrereservationTimeTableService {
 			}
 
 			validateTimeRangeOrThrow(item.bookingStartAt(), item.bookingEndAt());
+			validateWithinScheduleOrThrow(schedule, item.bookingStartAt(), item.bookingEndAt());
 
 			PrereservationTimeTable timeTable = prereservationTimeTableRepository
 				.findByPerformanceScheduleIdAndSectionId(scheduleId, item.sectionId())
@@ -80,6 +81,16 @@ public class PrereservationTimeTableService {
 
 	private void validateTimeRangeOrThrow(LocalDateTime startAt, LocalDateTime endAt) {
 		if (startAt.isAfter(endAt) || startAt.isEqual(endAt)) {
+			throw new BusinessException(PrereservationErrorCode.TIME_TABLE_NOT_CONFIGURED);
+		}
+	}
+
+	private void validateWithinScheduleOrThrow(PerformanceSchedule schedule, LocalDateTime startAt, LocalDateTime endAt) {
+		if (startAt.isBefore(schedule.getBookingOpenAt())) {
+			throw new BusinessException(PrereservationErrorCode.TIME_TABLE_NOT_CONFIGURED);
+		}
+
+		if (schedule.getBookingCloseAt() != null && endAt.isAfter(schedule.getBookingCloseAt())) {
 			throw new BusinessException(PrereservationErrorCode.TIME_TABLE_NOT_CONFIGURED);
 		}
 	}

--- a/src/main/java/com/back/b2st/global/init/DataInitializer.java
+++ b/src/main/java/com/back/b2st/global/init/DataInitializer.java
@@ -64,7 +64,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-@Profile("!test")
+@Profile("!test & !prod")
 @Transactional
 public class DataInitializer implements CommandLineRunner {
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -99,27 +99,11 @@ queue:
   test:
     enabled: false
 
-prereservation:
-  application:
-    strict: ${PRERESERVATION_APPLICATION_STRICT:true}
-  booking:
-    strict: ${PRERESERVATION_BOOKING_STRICT:true}
-  slot:
-    strict: ${PRERESERVATION_SLOT_STRICT:true}
-
 ---
 spring:
   config:
     activate:
       on-profile: dev
-
-prereservation:
-  application:
-    strict: ${PRERESERVATION_APPLICATION_STRICT:false}
-  booking:
-    strict: ${PRERESERVATION_BOOKING_STRICT:false}
-  slot:
-    strict: ${PRERESERVATION_SLOT_STRICT:false}
 
 # ==================== Circuit Breaker 설정 (추가) ====================
 resilience4j:

--- a/src/main/resources/templates/email/notification.html
+++ b/src/main/resources/templates/email/notification.html
@@ -50,6 +50,21 @@
             white-space: pre-line;
         }
 
+        .action-button {
+            display: inline-block;
+            padding: 12px 20px;
+            background: #ef4444;
+            color: #ffffff !important;
+            text-decoration: none;
+            border-radius: 8px;
+            font-weight: 700;
+            margin-top: 12px;
+        }
+
+        .action-button:hover {
+            background: #dc2626;
+        }
+
         .footer {
             background-color: #f8f9fa;
             padding: 20px;
@@ -69,6 +84,7 @@
         <div class="message-box" th:text="${message}">
             알림 메시지
         </div>
+        <a class="action-button" th:if="${actionUrl != null}" th:href="${actionUrl}" th:text="${actionText}">바로가기</a>
     </div>
     <div class="footer">
         <p>본 메일은 발신 전용이며, 회신되지 않습니다.</p>

--- a/src/test/java/com/back/b2st/domain/prereservation/booking/service/PrereservationHoldServiceTest.java
+++ b/src/test/java/com/back/b2st/domain/prereservation/booking/service/PrereservationHoldServiceTest.java
@@ -53,7 +53,7 @@ class PrereservationHoldServiceTest {
 	private static final Long SECTION_ID = 7L;
 
 	@Test
-	@DisplayName("validateSeatHoldAllowed(): BookingType이 PRERESERVE가 아니면 검증을 스킵한다")
+	@DisplayName("validateSeatHoldAllowed(): BookingType이 PRERESERVE가 아니면 BOOKING_TYPE_NOT_SUPPORTED 예외")
 	void validateHold_skipNonPrereserve() {
 		// given
 		PerformanceSchedule schedule = mock(PerformanceSchedule.class);
@@ -61,8 +61,9 @@ class PrereservationHoldServiceTest {
 		given(performanceScheduleRepository.findById(SCHEDULE_ID)).willReturn(Optional.of(schedule));
 
 		// when & then
-		assertThatCode(() -> prereservationHoldService.validateSeatHoldAllowed(MEMBER_ID, SCHEDULE_ID, SEAT_ID))
-			.doesNotThrowAnyException();
+		assertThatThrownBy(() -> prereservationHoldService.validateSeatHoldAllowed(MEMBER_ID, SCHEDULE_ID, SEAT_ID))
+			.isInstanceOf(BusinessException.class)
+			.hasMessageContaining(PrereservationErrorCode.BOOKING_TYPE_NOT_SUPPORTED.getMessage());
 		then(seatRepository).shouldHaveNoInteractions();
 		then(prereservationRepository).shouldHaveNoInteractions();
 	}

--- a/src/test/java/com/back/b2st/domain/prereservation/entry/service/PrereservationApplyServiceTest.java
+++ b/src/test/java/com/back/b2st/domain/prereservation/entry/service/PrereservationApplyServiceTest.java
@@ -271,7 +271,13 @@ class PrereservationApplyServiceTest {
 
 		// then
 		then(prereservationRepository).should().save(any(Prereservation.class));
-		then(emailSender).should().sendNotificationEmail(eq(email), eq("[TT] 신청 예매 사전 신청 완료"), anyString());
+		then(emailSender).should().sendNotificationEmail(
+			eq(email),
+			eq("[TT] 신청 예매 사전 신청 완료"),
+			anyString(),
+			eq("예매 바로가기"),
+			eq("https://doncrytt.vercel.app/my-page")
+		);
 	}
 
 	@Test

--- a/src/test/java/com/back/b2st/domain/prereservation/policy/service/PrereservationTimeTableServiceTest.java
+++ b/src/test/java/com/back/b2st/domain/prereservation/policy/service/PrereservationTimeTableServiceTest.java
@@ -168,7 +168,7 @@ class PrereservationTimeTableServiceTest {
 		Venue venue = mock(Venue.class);
 
 		given(schedule.getBookingType()).willReturn(BookingType.PRERESERVE);
-		given(schedule.getBookingOpenAt()).willReturn(LocalDateTime.now().plusDays(1));
+		given(schedule.getBookingOpenAt()).willReturn(LocalDateTime.now().minusHours(1));
 		given(schedule.getPerformance()).willReturn(performance);
 		given(performance.getVenue()).willReturn(venue);
 		given(venue.getVenueId()).willReturn(VENUE_ID);
@@ -176,4 +176,3 @@ class PrereservationTimeTableServiceTest {
 		return schedule;
 	}
 }
-


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 관련 이슈
- close #529 

</br>

## 작업 내용

- 운영(prod)에서 DataInitializer 시드가 실행되지 않도록 차단
- 사전신청 완료 이메일에 [예매 바로가기] 버튼 링크 추가
- 신청예매 검증 로직 보강(회차 타입/구역/시간대 검증 강화)


</br>

## 체크리스트
- [ ] 코딩 컨벤션 준수
- [ ] 불필요한 코드 제거
- [ ] 테스트 완료
